### PR TITLE
Fixed bug when calling Entries()

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -155,6 +155,7 @@ func (c *Cron) run() {
 				e.Prev = e.Next
 				e.Next = e.Schedule.Next(effective)
 			}
+			continue
 
 		case newEntry := <-c.add:
 			c.entries = append(c.entries, newEntry)
@@ -166,6 +167,9 @@ func (c *Cron) run() {
 		case <-c.stop:
 			return
 		}
+
+		// 'now' should be updated after newEntry and snapshot cases.
+		now = time.Now().Local()
 	}
 }
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -77,6 +77,31 @@ func TestAddWhileRunning(t *testing.T) {
 	}
 }
 
+// Test timing with Entries.
+func TestSnapshotEntries(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	cron := New()
+	cron.AddFunc("@every 2s", func() { wg.Done() })
+	cron.Start()
+	defer cron.Stop()
+
+	// Cron should fire in 2 seconds. After 1 second, call Entries.
+	select {
+	case <-time.After(ONE_SECOND):
+		cron.Entries()
+	}
+
+	// Even though Entries was called, the cron should fire at the 2 second mark.
+	select {
+	case <-time.After(ONE_SECOND):
+		t.FailNow()
+	case <-wait(wg):
+	}
+
+}
+
 // Test that the entries are correctly sorted.
 // Add a bunch of long-in-the-future entries, and an immediate entry, and ensure
 // that the immediate entry runs immediately.


### PR DESCRIPTION
I believe I have found and fixed a bug when calling the Entries() function. The "now" variable wasn't getting updated when the select hit the "<-c.snapshot" case. This was causing the "<-time.After(effective.Sub(now))" to wait longer than it should have.
