### PR TITLE
Using panic is not a proper way to handle errors.  This assumes that the...

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -88,8 +88,13 @@ func (c *Cron) AddFunc(spec string, cmd func()) {
 }
 
 // AddFunc adds a Job to the Cron to be run on the given schedule.
-func (c *Cron) AddJob(spec string, cmd Job) {
-	c.Schedule(Parse(spec), cmd)
+func (c *Cron) AddJob(spec string, cmd Job) error {
+	schedule, err := Parse(spec)
+	if err != nil {
+		return err
+	}
+	c.Schedule(schedule, cmd)
+	return nil
 }
 
 // Schedule adds a Job to the Cron to be run on the given schedule.

--- a/parser.go
+++ b/parser.go
@@ -1,7 +1,7 @@
 package cron
 
 import (
-	"log"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -14,7 +14,7 @@ import (
 // It accepts
 //   - Full crontab specs, e.g. "* * * * * ?"
 //   - Descriptors, e.g. "@midnight", "@every 1h30m"
-func Parse(spec string) Schedule {
+func Parse(spec string) (Schedule, error) {
 	if spec[0] == '@' {
 		return parseDescriptor(spec)
 	}
@@ -23,7 +23,7 @@ func Parse(spec string) Schedule {
 	// (second) (minute) (hour) (day of month) (month) (day of week, optional)
 	fields := strings.Fields(spec)
 	if len(fields) != 5 && len(fields) != 6 {
-		log.Panicf("Expected 5 or 6 fields, found %d: %s", len(fields), spec)
+		return nil, fmt.Errorf("Expected 5 or 6 fields, found %d: %s", len(fields), spec)
 	}
 
 	// If a sixth field is not provided (DayOfWeek), then it is equivalent to star.
@@ -31,34 +31,62 @@ func Parse(spec string) Schedule {
 		fields = append(fields, "*")
 	}
 
-	schedule := &SpecSchedule{
-		Second: getField(fields[0], seconds),
-		Minute: getField(fields[1], minutes),
-		Hour:   getField(fields[2], hours),
-		Dom:    getField(fields[3], dom),
-		Month:  getField(fields[4], months),
-		Dow:    getField(fields[5], dow),
+	s, err := getField(fields[0], seconds)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get seconds field, %s", err)
+	}
+	mi, err := getField(fields[1], minutes)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get minutes field, %s", err)
+	}
+	h, err := getField(fields[2], hours)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get hours field, %s", err)
+	}
+	dm, err := getField(fields[3], dom)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get day-of-month field, %s", err)
+	}
+	mo, err := getField(fields[4], months)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get month field, %s", err)
+	}
+	dw, err := getField(fields[5], dow)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get day-of-week field, %s", err)
 	}
 
-	return schedule
+	schedule := &SpecSchedule{
+		Second: s,
+		Minute: mi,
+		Hour:   h,
+		Dom:    dm,
+		Month:  mo,
+		Dow:    dw,
+	}
+
+	return schedule, nil
 }
 
 // getField returns an Int with the bits set representing all of the times that
 // the field represents.  A "field" is a comma-separated list of "ranges".
-func getField(field string, r bounds) uint64 {
+func getField(field string, r bounds) (uint64, error) {
 	// list = range {"," range}
 	var bits uint64
 	ranges := strings.FieldsFunc(field, func(r rune) bool { return r == ',' })
 	for _, expr := range ranges {
-		bits |= getRange(expr, r)
+		r, err := getRange(expr, r)
+		if err != nil {
+			return bits, err
+		}
+		bits |= r
 	}
-	return bits
+	return bits, nil
 }
 
 // getRange returns the bits indicated by the given expression:
 //   number | number "-" number [ "/" number ]
-func getRange(expr string, r bounds) uint64 {
-
+func getRange(expr string, r bounds) (uint64, error) {
 	var (
 		start, end, step uint
 		rangeAndStep     = strings.Split(expr, "/")
@@ -67,19 +95,26 @@ func getRange(expr string, r bounds) uint64 {
 	)
 
 	var extra_star uint64
+	var err error
 	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
 		start = r.min
 		end = r.max
 		extra_star = starBit
 	} else {
-		start = parseIntOrName(lowAndHigh[0], r.names)
+		start, err = parseIntOrName(lowAndHigh[0], r.names)
+		if err != nil {
+			return 0, err
+		}
 		switch len(lowAndHigh) {
 		case 1:
 			end = start
 		case 2:
-			end = parseIntOrName(lowAndHigh[1], r.names)
+			end, err = parseIntOrName(lowAndHigh[1], r.names)
+			if err != nil {
+				return 0, err
+			}
 		default:
-			log.Panicf("Too many hyphens: %s", expr)
+			return 0, fmt.Errorf("Too many hyphens: %s", expr)
 		}
 	}
 
@@ -87,50 +122,53 @@ func getRange(expr string, r bounds) uint64 {
 	case 1:
 		step = 1
 	case 2:
-		step = mustParseInt(rangeAndStep[1])
-
+		var err error
+		step, err = mustParseInt(rangeAndStep[1])
+		if err != nil {
+			return 0, err
+		}
 		// Special handling: "N/step" means "N-max/step".
 		if singleDigit {
 			end = r.max
 		}
 	default:
-		log.Panicf("Too many slashes: %s", expr)
+		return 0, fmt.Errorf("Too many slashes: %s", expr)
 	}
 
 	if start < r.min {
-		log.Panicf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
+		return 0, fmt.Errorf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
 	}
 	if end > r.max {
-		log.Panicf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
+		return 0, fmt.Errorf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
 	}
 	if start > end {
-		log.Panicf("Beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
+		return 0, fmt.Errorf("Beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
 	}
 
-	return getBits(start, end, step) | extra_star
+	return getBits(start, end, step) | extra_star, nil
 }
 
 // parseIntOrName returns the (possibly-named) integer contained in expr.
-func parseIntOrName(expr string, names map[string]uint) uint {
+func parseIntOrName(expr string, names map[string]uint) (uint, error) {
 	if names != nil {
 		if namedInt, ok := names[strings.ToLower(expr)]; ok {
-			return namedInt
+			return namedInt, nil
 		}
 	}
 	return mustParseInt(expr)
 }
 
 // mustParseInt parses the given expression as an int or panics.
-func mustParseInt(expr string) uint {
+func mustParseInt(expr string) (uint, error) {
 	num, err := strconv.Atoi(expr)
 	if err != nil {
-		log.Panicf("Failed to parse int from %s: %s", expr, err)
+		return 0, fmt.Errorf("Failed to parse int from %s: %s", expr, err)
 	}
 	if num < 0 {
-		log.Panicf("Negative number (%d) not allowed: %s", num, expr)
+		return 0, fmt.Errorf("Negative number (%d) not allowed: %s", num, expr)
 	}
 
-	return uint(num)
+	return uint(num), nil
 }
 
 // getBits sets all bits in the range [min, max], modulo the given step size.
@@ -156,7 +194,7 @@ func all(r bounds) uint64 {
 
 // parseDescriptor returns a pre-defined schedule for the expression, or panics
 // if none matches.
-func parseDescriptor(spec string) Schedule {
+func parseDescriptor(spec string) (Schedule, error) {
 	switch spec {
 	case "@yearly", "@annually":
 		return &SpecSchedule{
@@ -166,7 +204,7 @@ func parseDescriptor(spec string) Schedule {
 			Dom:    1 << dom.min,
 			Month:  1 << months.min,
 			Dow:    all(dow),
-		}
+		}, nil
 
 	case "@monthly":
 		return &SpecSchedule{
@@ -176,7 +214,7 @@ func parseDescriptor(spec string) Schedule {
 			Dom:    1 << dom.min,
 			Month:  all(months),
 			Dow:    all(dow),
-		}
+		}, nil
 
 	case "@weekly":
 		return &SpecSchedule{
@@ -186,7 +224,7 @@ func parseDescriptor(spec string) Schedule {
 			Dom:    all(dom),
 			Month:  all(months),
 			Dow:    1 << dow.min,
-		}
+		}, nil
 
 	case "@daily", "@midnight":
 		return &SpecSchedule{
@@ -196,7 +234,7 @@ func parseDescriptor(spec string) Schedule {
 			Dom:    all(dom),
 			Month:  all(months),
 			Dow:    all(dow),
-		}
+		}, nil
 
 	case "@hourly":
 		return &SpecSchedule{
@@ -206,18 +244,17 @@ func parseDescriptor(spec string) Schedule {
 			Dom:    all(dom),
 			Month:  all(months),
 			Dow:    all(dow),
-		}
+		}, nil
 	}
 
 	const every = "@every "
 	if strings.HasPrefix(spec, every) {
 		duration, err := time.ParseDuration(spec[len(every):])
 		if err != nil {
-			log.Panicf("Failed to parse duration %s: %s", spec, err)
+			return nil, fmt.Errorf("Failed to parse duration %s: %s", spec, err)
 		}
-		return Every(duration)
+		return Every(duration), nil
 	}
 
-	log.Panicf("Unrecognized descriptor: %s", spec)
-	return nil
+	return nil, fmt.Errorf("Unrecognized descriptor: %s", spec)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -29,7 +29,10 @@ func TestRange(t *testing.T) {
 	}
 
 	for _, c := range ranges {
-		actual := getRange(c.expr, bounds{c.min, c.max, nil})
+		actual, err := getRange(c.expr, bounds{c.min, c.max, nil})
+		if err != nil {
+			t.Fatalf("unable to get range: %s", err)
+		}
 		if actual != c.expected {
 			t.Errorf("%s => (expected) %d != %d (actual)", c.expr, c.expected, actual)
 		}
@@ -49,7 +52,10 @@ func TestField(t *testing.T) {
 	}
 
 	for _, c := range fields {
-		actual := getField(c.expr, bounds{c.min, c.max, nil})
+		actual, err := getField(c.expr, bounds{c.min, c.max, nil})
+		if err != nil {
+			t.Fatalf("unable to get field: %s", err)
+		}
 		if actual != c.expected {
 			t.Errorf("%s => (expected) %d != %d (actual)", c.expr, c.expected, actual)
 		}
@@ -106,7 +112,10 @@ func TestSpecSchedule(t *testing.T) {
 	}
 
 	for _, c := range entries {
-		actual := Parse(c.expr)
+		actual, err := Parse(c.expr)
+		if err != nil {
+			t.Fatalf("unable to parse spec (%s): %s", c.expr, err)
+		}
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("%s => (expected) %b != %b (actual)", c.expr, c.expected, actual)
 		}

--- a/spec_test.go
+++ b/spec_test.go
@@ -56,7 +56,11 @@ func TestActivation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := Parse(test.spec).Next(getTime(test.time).Add(-1 * time.Second))
+		schedule, err := Parse(test.spec)
+		if err != nil {
+			t.Fatalf("Error during parse: %s", err)
+		}
+		actual := schedule.Next(getTime(test.time).Add(-1 * time.Second))
 		expected := getTime(test.time)
 		if test.expected && expected != actual || !test.expected && expected == actual {
 			t.Errorf("Fail evaluating %s on %s: (expected) %s != %s (actual)",
@@ -117,7 +121,11 @@ func TestNext(t *testing.T) {
 	}
 
 	for _, c := range runs {
-		actual := Parse(c.spec).Next(getTime(c.time))
+		schedule, err := Parse(c.spec)
+		if err != nil {
+			t.Fatalf("Error during parse: %s", err)
+		}
+		actual := schedule.Next(getTime(c.time))
 		expected := getTime(c.expected)
 		if !actual.Equal(expected) {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)


### PR DESCRIPTION
... developer is only ever evaluating static cron specs that aren't configured dynamically.  If I wanted to utilize the Parse function in this library, and manage crons through some type of configuration interface, I would have no way to recover from parsing an improperly-formatted spec, other than deferred recover.  There is a reason we don't see this practice inside the stdlib.  Using errors allows me to recover from that scenario with ease.
