### PR TITLE
Add support for DST

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -104,9 +104,6 @@ Time zones
 All interpretation and scheduling is done in the machine's local time zone (as
 provided by the Go time package (http://www.golang.org/pkg/time).
 
-Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
-not be run!
-
 Thread safety
 
 Since the Cron service runs concurrently with the calling code, some amount of


### PR DESCRIPTION
This addition takes DST into account and prevents jobs from being repeated or skipped.

Before:

```
0 0 2 * * *
Start: Sun, 09 Mar 2014 01:00:00 PST
+1 Hr: Sun, 09 Mar 2014 03:00:00 PDT
Next: Mon, 10 Mar 2014 02:00:00 PDT <-- Day skipped!!!
Next: Tue, 11 Mar 2014 02:00:00 PDT
Next: Wed, 12 Mar 2014 02:00:00 PDT
----------

0 0 1 * * *
Start: Sun, 02 Nov 2014 01:00:00 PDT
+1 Hr: Sun, 02 Nov 2014 01:00:00 PST
Next: Sun, 02 Nov 2014 01:00:00 PST <-- Day repeated!!!
Next: Sun, 02 Nov 2014 01:00:00 PST
Next: Sun, 02 Nov 2014 01:00:00 PST
----------

0 0 * * * *
Start: Sun, 09 Mar 2014 01:00:00 PST
+1 Hr: Sun, 09 Mar 2014 03:00:00 PDT
Next: Sun, 09 Mar 2014 03:00:00 PDT
Next: Sun, 09 Mar 2014 04:00:00 PDT
Next: Sun, 09 Mar 2014 05:00:00 PDT
----------

0 0 * * * *
Start: Sun, 02 Nov 2014 01:00:00 PDT
+1 Hr: Sun, 02 Nov 2014 01:00:00 PST
Next: Sun, 02 Nov 2014 01:00:00 PST <--- repeat!!!
Next: Sun, 02 Nov 2014 01:00:00 PST <--- repeat!!!
Next: Sun, 02 Nov 2014 01:00:00 PST <--- repeat!!!
----------
```

After:

```
0 0 2 * * *
Start: Sun, 09 Mar 2014 01:00:00 PST
+1 Hr: Sun, 09 Mar 2014 03:00:00 PDT
Next: Sun, 09 Mar 2014 03:00:00 PDT <-- next hour because 2:00 doesn't exist
Next: Mon, 10 Mar 2014 02:00:00 PDT
Next: Tue, 11 Mar 2014 02:00:00 PDT
----------

0 0 1 * * *
Start: Sun, 02 Nov 2014 01:00:00 PDT
+1 Hr: Sun, 02 Nov 2014 01:00:00 PST
Next: Mon, 03 Nov 2014 01:00:00 PST <-- task already run at 1:00, so 1:00 the next day
Next: Tue, 04 Nov 2014 01:00:00 PST
Next: Wed, 05 Nov 2014 01:00:00 PST
----------

0 0 * * * *
Start: Sun, 09 Mar 2014 01:00:00 PST
+1 Hr: Sun, 09 Mar 2014 03:00:00 PDT
Next: Sun, 09 Mar 2014 03:00:00 PDT
Next: Sun, 09 Mar 2014 04:00:00 PDT
Next: Sun, 09 Mar 2014 05:00:00 PDT
----------

0 0 * * * *
Start: Sun, 02 Nov 2014 01:00:00 PDT
+1 Hr: Sun, 02 Nov 2014 01:00:00 PST
Next: Sun, 02 Nov 2014 02:00:00 PST <-- no repeat
Next: Sun, 02 Nov 2014 03:00:00 PST
Next: Sun, 02 Nov 2014 04:00:00 PST
----------
```

Code used: https://gist.github.com/lukescott/8484861

In the old code the multiple repeats seen here:

```
0 0 * * * *
Start: Sun, 02 Nov 2014 01:00:00 PDT
+1 Hr: Sun, 02 Nov 2014 01:00:00 PST
Next: Sun, 02 Nov 2014 01:00:00 PST <--- repeat!!!
Next: Sun, 02 Nov 2014 01:00:00 PST <--- repeat!!!
Next: Sun, 02 Nov 2014 01:00:00 PST <--- repeat!!!
```

Was caused by the Date func on hour/minute/second:

```go
 t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), 0, 0, t.Location())
// And fixed by:
t = t.Truncate(time.Second)
```

The Date func causes the time to flip to the wrong side of DST causing an infinite loop.

The order for hour, minute and second was changed to second, minute, and hour. This was necessary for the half-hour DST tests to pass. All other non-DST tests pass, although it might be good to confirm that change won't break anything else that isn't covered. 

All commits have been squashed.