### PR TITLE
Enforce custom import path

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -1,5 +1,5 @@
 // Package cron implements a cron spec parser and runner.
-package cron //import "gopkg.in/robfig/cron.v2"
+package cron // import "gopkg.in/robfig/cron.v2"
 
 import (
 	"sort"

--- a/cron.go
+++ b/cron.go
@@ -1,5 +1,5 @@
 // Package cron implements a cron spec parser and runner.
-package cron
+package cron //import "gopkg.in/robfig/cron.v2"
 
 import (
 	"sort"


### PR DESCRIPTION
Force a custom import paths introduced in go 1.4. See: [custom paths](https://docs.google.com/a/daddye.it/document/d/1jVFkZTcYbNLaTxXD9OcGfn7vYv5hWtPx9--lTx1gPMs)

This will avoid conflicts with master.