### PR TITLE
add IsRunning method

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -197,3 +197,8 @@ func (c *Cron) entrySnapshot() []*Entry {
 	}
 	return entries
 }
+
+// Return cron is running
+func (c *Cron) IsRunning() bool{
+	return c.running
+}

--- a/cron_test.go
+++ b/cron_test.go
@@ -189,6 +189,28 @@ func TestLocalTimezone(t *testing.T) {
 	}
 }
 
+func TestIsRunning(t *testing.T) {
+	cron := New()
+	cron.AddFunc("0 0 0 1 1 ?", func() {})
+
+	if cron.IsRunning() != false{
+		t.Errorf("The cron isn't running yet, but IsRunning return true")
+		t.FailNow()
+	}
+
+	cron.Start()
+	if cron.IsRunning() != true{
+		t.Errorf("The cron is running, but IsRunning return false")
+		t.FailNow()
+	}
+
+	cron.Stop()
+	if cron.IsRunning() != false{
+		t.Errorf("The cron is stop, but IsRunning return true")
+		t.FailNow()
+	}
+}
+
 type testJob struct {
 	wg   *sync.WaitGroup
 	name string


### PR DESCRIPTION
The Cron.running field is private.
So when we want to check cron is running, we need create other flag and management it.

It's not simple.
This change add getter for Cron.running field.