### PR TITLE
Fix problems with times in timezone offsets which are not multiples o…

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -108,7 +108,7 @@ WRAP:
 	for 1<<uint(t.Hour())&s.Hour == 0 {
 		if !added {
 			added = true
-			t = t.Truncate(time.Hour)
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
 		}
 		t = t.Add(1 * time.Hour)
 


### PR DESCRIPTION
…f an hour.

Truncate does something we do not expect in the case of non integer
hour timezone offset. Its basically rounding to hour from t = 0. Which
in this case is Unix t=0 ... which means it rounds to the half hour.