### PR TITLE
Correctly schedule new entries

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -164,7 +164,7 @@ func (c *Cron) run() {
 
 		case newEntry := <-c.add:
 			c.entries = append(c.entries, newEntry)
-			newEntry.Next = newEntry.Schedule.Next(now)
+			newEntry.Next = newEntry.Schedule.Next(time.Now().Local())
 
 		case <-c.snapshot:
 			c.snapshot <- c.entrySnapshot()

--- a/cron_test.go
+++ b/cron_test.go
@@ -77,6 +77,22 @@ func TestAddWhileRunning(t *testing.T) {
 	}
 }
 
+// Test for #34. Adding a job after calling start results in multiple job invocations
+func TestAddWhileRunningWithDelay(t *testing.T) {
+	cron := New()
+	cron.Start()
+	defer cron.Stop()
+	time.Sleep(5 * time.Second)
+	var calls = 0
+	cron.AddFunc("* * * * * *", func() { calls += 1 });
+
+	<- time.After(ONE_SECOND)
+	if calls != 1 {
+		fmt.Printf("called %d times, expected 1\n", calls)
+		t.Fail()
+	}
+}
+
 // Test timing with Entries.
 func TestSnapshotEntries(t *testing.T) {
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
When a new entry is added to a running cron, use time.Now().Local() to schedule the first run of the task. The existing value of "now" could be very old if no other jobs have run recently.

This fixes #34.