### PR TITLE
check if it is running when calling start()

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -123,6 +123,9 @@ func (c *Cron) Entries() []*Entry {
 
 // Start the cron scheduler in its own go-routine.
 func (c *Cron) Start() {
+	if c.running {
+		return
+	}
 	c.running = true
 	go c.run()
 }

--- a/cron.go
+++ b/cron.go
@@ -121,7 +121,7 @@ func (c *Cron) Entries() []*Entry {
 	return c.entrySnapshot()
 }
 
-// Start the cron scheduler in its own go-routine.
+// Start the cron scheduler in its own go-routine if it is not running, otherwize it does nothing.
 func (c *Cron) Start() {
 	if c.running {
 		return

--- a/cron.go
+++ b/cron.go
@@ -121,7 +121,7 @@ func (c *Cron) Entries() []*Entry {
 	return c.entrySnapshot()
 }
 
-// Start the cron scheduler in its own go-routine if it is not running, otherwize it does nothing.
+// Start the cron scheduler in its own go-routine, or no-op if already started.
 func (c *Cron) Start() {
 	if c.running {
 		return


### PR DESCRIPTION
fix a bug,

call Start() more than once will start multiple run() goroutines to run the jobs.