### PR TITLE
Fix larger amount of entries after host sleep

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -174,7 +174,7 @@ func (c *Cron) run() {
 				}
 				go c.runWithRecovery(e.Job)
 				e.Prev = e.Next
-				e.Next = e.Schedule.Next(effective)
+				e.Next = e.Schedule.Next(now)
 			}
 			continue
 


### PR DESCRIPTION
Hi @robfig ,

I discovered a strange issue related to entries scheduling. Let's consider an application with running cron which processes scheduled entries. If the host (macbook?) goes asleep (lid down) and after some time wakes up, the scheduler will process as many entries as cron intervals.
Fix, I provided, prevents from running an overdose of scheduled entries one by one, and brings it to one entry run.

@robfig, please review the little code change and merge if possible.

Best regards,
Marcin