### PR TITLE
Step of range should be a positive number

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -114,6 +114,9 @@ func getRange(expr string, r bounds) uint64 {
 	if start > end {
 		log.Panicf("Beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
 	}
+	if step == 0 {
+		log.Panicf("Step of range should be a positive number: %s", expr)
+	}
 
 	return getBits(start, end, step) | extra_star
 }


### PR DESCRIPTION
Step 0 will cause the parse function loop forever.