### PR TITLE
Add explanation to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 [![GoDoc](http://godoc.org/github.com/robfig/cron?status.png)](http://godoc.org/github.com/robfig/cron) 
 [![Build Status](https://travis-ci.org/robfig/cron.svg?branch=master)](https://travis-ci.org/robfig/cron)
+
+**See `doc.go` file.**


### PR DESCRIPTION
It's not super clear that the actual Readme is inside `doc.go` (which is ok, but can be confusing for some people).