### PR TITLE
Add method capable of parsing standard cron spec

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -115,3 +115,23 @@ func TestSpecSchedule(t *testing.T) {
 		}
 	}
 }
+
+func TestStandardSpecSchedule(t *testing.T) {
+	entries := []struct {
+		expr     string
+		expected Schedule
+	}{
+		{"5 * * * *", &SpecSchedule{1 << seconds.min, 1 << 5, all(hours), all(dom), all(months), all(dow)}},
+		{"@every 5m", ConstantDelaySchedule{time.Duration(5) * time.Minute}},
+	}
+
+	for _, c := range entries {
+		actual, err := ParseStandard(c.expr)
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("%s => (expected) %b != %b (actual)", c.expr, c.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Currently Parse method accepts 5 or 6 entries, where the first field denotes seconds. `ParseStandard` method follows standard cron spec requiring to pass exactly 5 entries where the first is minute and last
is day of week. See https://en.wikipedia.org/wiki/Cron.

Fixes #58.

@robfig as promised some time ago, ptal
@bryanvpham fyi