### PR TITLE
Parser options

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -18,7 +18,7 @@ const (
 	Dom
 	Month
 	Dow
-	DowOptinal
+	DowOptional
 	Descriptor
 )
 
@@ -47,7 +47,7 @@ type Parser struct {
 
 func NewParser(options ParseOption) Parser {
 	optionals := 0
-	if options&DowOptinal > 0 {
+	if options&DowOptional > 0 {
 		options |= Dow
 		optionals++
 	}
@@ -120,7 +120,7 @@ func expandFields(fields []string, options ParseOption) []string {
 }
 
 var defaultParser = NewParser(
-	Second | Minute | Hour | Dom | Month | DowOptinal | Descriptor,
+	Second | Minute | Hour | Dom | Month | DowOptional | Descriptor,
 )
 
 // Parse returns a new crontab schedule representing the given spec.

--- a/spec.go
+++ b/spec.go
@@ -151,7 +151,6 @@ func dayMatches(s *SpecSchedule, t time.Time) bool {
 		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
 		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
 	)
-
 	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
 		return domMatch && dowMatch
 	}


### PR DESCRIPTION
Parse options https://github.com/webconnex/cron/tree/parser-options
 This adds `Parser` and `NewParser` with the ability to:

 * Select which fields are included. So you can exclude seconds, or any other field you don't want to use.
 * Set other options that might be useful, like making certain assumptions about the schedule.
 
 The Parse function now looks like this:
 ```go

  var defaultParser = NewParser(
      Second | Minute | Hour | Dom | Month | DowOptinal | Descriptor,
  )
  
  // Parse returns a new crontab schedule representing the given spec.
  // It returns a descriptive error if the spec is not valid.
  //
  // It accepts
  //   - Full crontab specs, e.g. "* * * * * ?"
  //   - Descriptors, e.g. "@midnight", "@every 1h30m"
  func Parse(spec string) (_ Schedule, err error) {
      return defaultParser.Parse(spec)
  }
 ```

  This could be a resolution for #58. All you would need to do is remove `Second` and it would be spec compliant. But for those who need it, they can create a new parser with the option.

  I'm not sure about Dow being optional and being "spec complaint" - but there are two options for this - `Dow` and `DowOptional` which are interchangeable - one makes it required, the other allows you to omit it.

(See #69)