### PR TITLE
Fix: Cron.run() was resetting the timezone

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -183,6 +183,7 @@ func (c *Cron) run() {
 		timer := time.NewTimer(effective.Sub(now))
 		select {
 		case now = <-timer.C:
+			now = now.In(c.location)
 			// Run every entry whose next time was this effective time.
 			for _, e := range c.entries {
 				if e.Next != effective {

--- a/cron_test.go
+++ b/cron_test.go
@@ -219,11 +219,11 @@ func TestRunningMultipleSchedules(t *testing.T) {
 // Test that the cron is run in the local time zone (as opposed to UTC).
 func TestLocalTimezone(t *testing.T) {
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
+	wg.Add(2)
 
 	now := time.Now().Local()
-	spec := fmt.Sprintf("%d %d %d %d %d ?",
-		now.Second()+1, now.Minute(), now.Hour(), now.Day(), now.Month())
+	spec := fmt.Sprintf("%d,%d %d %d %d %d ?",
+		now.Second()+1, now.Second()+2, now.Minute(), now.Hour(), now.Day(), now.Month())
 
 	cron := New()
 	cron.AddFunc(spec, func() { wg.Done() })
@@ -231,7 +231,7 @@ func TestLocalTimezone(t *testing.T) {
 	defer cron.Stop()
 
 	select {
-	case <-time.After(ONE_SECOND):
+	case <-time.After(ONE_SECOND * 2):
 		t.FailNow()
 	case <-wait(wg):
 	}
@@ -240,7 +240,7 @@ func TestLocalTimezone(t *testing.T) {
 // Test that the cron is run in the given time zone (as opposed to local).
 func TestNonLocalTimezone(t *testing.T) {
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
+	wg.Add(2)
 
 	loc, err := time.LoadLocation("Atlantic/Cape_Verde")
 	if err != nil {
@@ -249,8 +249,8 @@ func TestNonLocalTimezone(t *testing.T) {
 	}
 
 	now := time.Now().In(loc)
-	spec := fmt.Sprintf("%d %d %d %d %d ?",
-		now.Second()+1, now.Minute(), now.Hour(), now.Day(), now.Month())
+	spec := fmt.Sprintf("%d,%d %d %d %d %d ?",
+		now.Second()+1, now.Second()+2, now.Minute(), now.Hour(), now.Day(), now.Month())
 
 	cron := NewWithLocation(loc)
 	cron.AddFunc(spec, func() { wg.Done() })
@@ -258,7 +258,7 @@ func TestNonLocalTimezone(t *testing.T) {
 	defer cron.Stop()
 
 	select {
-	case <-time.After(ONE_SECOND):
+	case <-time.After(ONE_SECOND * 2):
 		t.FailNow()
 	case <-wait(wg):
 	}


### PR DESCRIPTION
time.Timer() does not return a timezone within time.Time, since Timer is unaware of the custom timezone as it only accepts time.Duration when it's initialized.
Thus the receiver needs to take care of the timezone.

```go
// NewTimer only receives time.Duration
func NewTimer(d Duration) *Timer

// And time.Duration only holds int64 but no timezone specifier
type Duration int64
```