### PR TITLE
Adding fixed schedules and persistent jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+*.iml

--- a/cron.go
+++ b/cron.go
@@ -130,6 +130,15 @@ func (f FuncJob) Run() {
 	f()
 }
 
+// creates and initialize arbitrary job
+func (c *Cron) NewArbitraryJob(functionToRun string, parameters ...interface{}) *ArbitraryJob {
+	return &ArbitraryJob{
+		cron: c,
+		ScheduledJob: functionToRun,
+		Parameters: parameters,
+	}
+}
+
 // AddFunc adds a func to the Cron to be run on the given schedule.
 func (c *Cron) AddFunc(spec string, cmd func()) error {
 	return c.AddJob(spec, FuncJob(cmd))

--- a/cron.go
+++ b/cron.go
@@ -109,6 +109,14 @@ func New() *Cron {
 	return NewWithLocation(time.Now().Location())
 }
 
+func NewWithFunctions(jobs map[string]ScheduledJob) *Cron {
+	cron := NewWithLocation(time.Now().Location())
+	for functionName, function := range jobs {
+		cron.RegisterFunction(functionName, function)
+	}
+	return cron
+}
+
 // NewWithLocation returns a new Cron job runner.
 func NewWithLocation(location *time.Location) *Cron {
 	return &Cron{

--- a/cron.go
+++ b/cron.go
@@ -408,3 +408,12 @@ func parseSchedule(unparsedSchedule interface{}) (Schedule, error) {
 	}
 	return nil, nil
 }
+
+func (c *Cron) RegisterFunction(name string, job ScheduledJob) ScheduledJob {
+	var scheduledJob ScheduledJob
+	if _, ok := c.functions[name]; ok {
+		scheduledJob = c.functions[name]
+	}
+	c.functions[name] = job
+	return scheduledJob
+}

--- a/cron.go
+++ b/cron.go
@@ -365,6 +365,10 @@ func NewFromReader(reader io.Reader) (*Cron, error) {
 	if err != nil {
 		return nil, err
 	}
+	// no input means nothing to restore
+	if len(data) == 0 {
+		return cron, nil
+	}
 	err = json.Unmarshal([]byte(data), &container)
 	if err != nil {
 		return nil, err

--- a/cron_test.go
+++ b/cron_test.go
@@ -136,6 +136,44 @@ func TestFixedSchedule(t *testing.T) {
 	}
 }
 
+// Adds a job and removes it - it should never be called.
+func TestCron_RemoveIndex(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	cron := New()
+	cron.AddOneOffFuncWithIndex(time.Now().Add(time.Second), func() { wg.Done() }, "test1")
+	cron.Start()
+	defer cron.Stop()
+	cron.RemoveIndex("test1")
+
+	// wait 1.01 secs, if we got called in 1.00 sec we failed as the job has been removed.
+	select {
+	case <-time.After(ONE_SECOND):
+	case <-wait(wg):
+		t.FailNow()
+	}
+}
+
+// Adds a job and removes it - it should never be called.
+func TestCron_RemoveIndex2(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	cron := New()
+	cron.AddOneOffFuncWithIndex(time.Now().Add(time.Second), func() { wg.Done() }, "test2")
+	cron.Start()
+	defer cron.Stop()
+	cron.RemoveIndex("test1")
+
+	// wait 2 secs, the job should run in 1 sec.
+	select {
+	case <-time.After(2 * time.Second):
+		t.FailNow()
+	case <-wait(wg):
+	}
+}
+
 func TestFuncPanicRecovery(t *testing.T) {
 	cron := New()
 	cron.Start()

--- a/cron_test.go
+++ b/cron_test.go
@@ -34,10 +34,10 @@ func TestCron_Persist(t *testing.T) {
 	cron := New()
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	cron.functions["job1"] = ScheduledJob(func(params...interface{}) error {
+	cron.RegisterFunction("job1", ScheduledJob(func(params...interface{}) error {
 		wg.Done()
 		return nil
-	})
+	}))
 	cron.AddJob("* * * * * ?", ArbitraryJob{Parameters: []interface{}{}, ScheduledJob: "job1", cron: cron})
 	cron.Start()
 	defer cron.Stop()

--- a/doc.go
+++ b/doc.go
@@ -22,6 +22,44 @@ them in their own goroutines.
 	..
 	c.Stop()  // Stop the scheduler (does not stop any jobs already running).
 
+One off jobs. Functions are called at a scheduled time. To schedule a job to be
+run at specified time call cron.
+
+	c := cron.New()
+   c.AddOneOffFunc(time.Now().Add(2 * time.Second), func() { fmt.Println("Will run in 2 seconds") }
+   c.Start()
+
+If you want to persist the state of a cron into a writer you can do so by calling
+
+   cron.PersistToWriter(writer)
+
+However for any state persisting to make sense you have to use a different type of functions.
+They're called PresetJob. It's not so difficult to take advantage of PresetJobs. First you have
+to register a function with a cron.
+
+   cron := New()
+   cron.RegisterPresetJob("preset1", ScheduledJob(func(params...interface{}) error {
+     name := params[0].(string)
+     fmt.Println("I'm a present job: " + name)
+     return nil
+   }))
+   cron.AddOneOffJob(time.Now().Add(2 * time.Second), cron.NewArbitraryJob("preset1", "preset1"))
+   cron.Start()
+   cron.PersistToWriter(writer)
+
+If you want to restore the state of a cron use the
+
+   cron, err := NewFromReader(reader)
+   cron.RegisterPresetJob("preset1", ScheduledJob(func(params...interface{}) error {
+     name := params[0].(string)
+     fmt.Println("I'm a present job: " + name)
+     return nil
+   }))
+   cron.Start()
+
+Please note that for any restored cron to make sense you have register the same functions
+under the same names.
+
 CRON Expression Format
 
 A cron expression represents a set of times, using 6 space-separated fields.

--- a/fixed.go
+++ b/fixed.go
@@ -1,0 +1,29 @@
+package cron
+
+import (
+	"time"
+	"encoding/json"
+)
+
+type FixedSchedule struct {
+	FixedTime time.Time
+}
+
+func (s *FixedSchedule) Next(t time.Time) time.Time {
+	if s.FixedTime.After(t) {
+		return s.FixedTime
+	}
+	return time.Time{}
+}
+
+func (f *FixedSchedule)MarshalJSON()([]byte, error) {
+	data := struct {
+		FixedTime time.Time
+		Cat       string
+	}{
+		FixedTime: f.FixedTime,
+		Cat: "FixedSchedule",
+	}
+	return json.Marshal(data)
+}
+

--- a/fixed_test.go
+++ b/fixed_test.go
@@ -1,0 +1,25 @@
+package cron
+
+import (
+	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFixedSchedule_Next(t *testing.T) {
+	now := time.Now()
+	schedule := FixedSchedule{
+		FixedTime: now,
+	}
+	next := schedule.Next(now.Add (time.Second * -1))
+	assert.Equal(t, now , next)
+}
+
+func TestFixedSchedule_Next2(t *testing.T) {
+	now := time.Now()
+	schedule := FixedSchedule{
+		FixedTime: now,
+	}
+	next := schedule.Next(now.Add(time.Second))
+	assert.Equal(t, time.Time{} , next)
+}

--- a/spec.go
+++ b/spec.go
@@ -1,12 +1,32 @@
 package cron
 
-import "time"
+import (
+	"time"
+	"encoding/json"
+	"strconv"
+)
 
 // SpecSchedule specifies a duty cycle (to the second granularity), based on a
 // traditional crontab specification. It is computed initially and stored as bit sets.
 type SpecSchedule struct {
 	Second, Minute, Hour, Dom, Month, Dow uint64
 }
+
+func (s *SpecSchedule)MarshalJSON()([]byte, error) {
+	data := struct {
+		Second, Minute, Hour, Dom, Month, Dow, Cat string
+	}{
+		Second: strconv.FormatUint(s.Second, 10),
+		Minute: strconv.FormatUint(s.Minute, 10),
+		Hour: strconv.FormatUint(s.Hour, 10),
+		Dom: strconv.FormatUint(s.Dom, 10),
+		Month: strconv.FormatUint(s.Month, 10),
+		Dow: strconv.FormatUint(s.Dow, 10),
+		Cat: "SpecSchedule",
+	}
+	return json.Marshal(data)
+}
+
 
 // bounds provides a range of acceptable values (plus a map of name to value).
 type bounds struct {


### PR DESCRIPTION
This PR will introduce a new type of jobs - I call them _one offs_ - fixed schedules. 

It also adds the ability to persist the state of a cron. It only works for a new type of jobs, I call them _PresetJobs_, where the preset job is generally a function associated with a cron. Scheduling such job means telling the cron to run a job by name with parameters. 

U understand that this PR adds fundamentally new functionality to this project so feel free to reject it. 

By the way, documentation  and test have been updated.
