### PR TITLE
Run scheduled job additionally on startup

### DIFF
--- a/runonstartup.go
+++ b/runonstartup.go
@@ -1,0 +1,36 @@
+package cron
+
+import "time"
+
+// RunOnStartupSchedule allows to run job on cron startup.
+type RunOnStartupSchedule struct {
+	schedule  Schedule
+	activated bool
+}
+
+// OnStartup method creates a new instance of RunOnStartupSchedule wrapping given schedule.
+func OnStartup(schedule Schedule) *RunOnStartupSchedule {
+	return &RunOnStartupSchedule{
+		schedule: schedule,
+	}
+}
+
+// OnStartupSpec creates a new instance of RunOnStartupSchedule wrapping a crontab schedule,
+// representing given spec.
+func OnStartupSpec(spec string) (*RunOnStartupSchedule, error) {
+	schedule, err := Parse(spec)
+	if err != nil {
+		return nil, err
+	}
+	return OnStartup(schedule), nil
+}
+
+// Next returns the next time this should be run. If the job hasn't been run yet,
+// it returns the current time.
+func (s *RunOnStartupSchedule) Next(t time.Time) time.Time {
+	if !s.activated {
+		s.activated = true
+		return time.Now()
+	}
+	return s.schedule.Next(t)
+}

--- a/runonstartup_test.go
+++ b/runonstartup_test.go
@@ -1,0 +1,96 @@
+package cron
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type mockedSchedule struct {
+	expected time.Time
+}
+
+func (m *mockedSchedule) Next(time.Time) time.Time {
+	return m.expected
+}
+
+func TestOnStartup(t *testing.T) {
+	// given
+	parsedSchedule, err := Parse("@every 1m")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// when
+	onStartupSchedule := OnStartup(parsedSchedule)
+
+	// then
+	if onStartupSchedule == nil {
+		t.Error("onStartupSchedule can't be nil")
+	}
+
+	if onStartupSchedule.schedule != parsedSchedule {
+		t.Error("onStartupSchedule.schedule must be equal to parsedSchedule")
+	}
+
+	if onStartupSchedule.activated {
+		t.Error("onStartupSchedule hasn't been run so it is shouldn't be already activated")
+	}
+}
+
+func TestOnStartupSpec(t *testing.T) {
+	// given
+	delay := 60 * time.Minute
+	spec := fmt.Sprintf("@every %v", delay)
+
+	// when
+	onStartupSpecSchedule, err := OnStartupSpec(spec)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// then
+	if onStartupSpecSchedule == nil {
+		t.Error("onStartupSpecSchedule can't be nil")
+	}
+
+	if onStartupSpecSchedule.schedule == nil {
+		t.Error("onStartupSpecSchedule.schedule can't be nil")
+	}
+
+	constantDelaySchedule, ok := onStartupSpecSchedule.schedule.(ConstantDelaySchedule)
+	if !ok {
+		t.Error("onStartupSpecSchedule.schedule must be instance of ConstantDelaySchedule")
+	}
+
+	if constantDelaySchedule.Delay != delay {
+		t.Error("constantDelaySchedule is not correctly configured")
+	}
+}
+
+func TestOnStartupNext(t *testing.T) {
+	// given
+	now := time.Now()
+	any := now.Add(123 * time.Minute)
+	expectedNext := any.Add(456 * time.Minute)
+
+	mockedSchedule := &mockedSchedule{expected: expectedNext}
+	onStartupSchedule := OnStartup(mockedSchedule)
+
+	// when
+	next := onStartupSchedule.Next(now)
+
+	// then
+
+	if now.Add(1 * time.Second).Before(next) {
+		t.Error("Not activated schedule should be run immediately")
+	}
+
+	// when
+	next = onStartupSchedule.Next(any)
+
+	// then
+	if next != expectedNext {
+		t.Error("next activation time should be set accordingly to ConstantDelaySchedule")
+	}
+}


### PR DESCRIPTION
Hi,

I came to a use case when I wanted to run a cron job on startup (of cron mechanism) and let the job be run later accordingly to the given spec. 
Sample usage: this modification lets me fill a table of "some" job statuses (e.g. some health checks built upon cron) right after initialization.

Please review this PR (unit tests included).

Happy New Year,
Marcin Tojek

/cc @robfig 