### PR TITLE
Remove duplicate doc comment

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -1,5 +1,3 @@
-// This library implements a cron spec parser and runner.  See the README for
-// more details.
 package cron
 
 import (


### PR DESCRIPTION
doc in README has already been moved in doc.go,  so docs in cron.go is duplicate and useless.