### PR TITLE
Add check for empty spec

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -76,6 +76,9 @@ func NewParser(options ParseOption) Parser {
 // It returns a descriptive error if the spec is not valid.
 // It accepts crontab specs and features configured by NewParser.
 func (p Parser) Parse(spec string) (Schedule, error) {
+	if len(spec) == 0 {
+		return nil, fmt.Errorf("Empty spec string")
+	}
 	if spec[0] == '@' && p.options&Descriptor > 0 {
 		return parseDescriptor(spec)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -175,6 +175,10 @@ func TestParse(t *testing.T) {
 			expr: "* * * *",
 			err:  "Expected 5 to 6 fields",
 		},
+		{
+			expr: "",
+			err:  "Empty spec string",
+		},
 	}
 
 	for _, c := range entries {


### PR DESCRIPTION
@janetkuo pointed me we're missing empty check in `ParseStandard`, so here it is.

@robfig ptal, as always test added :)