### PR TITLE
Add method to cleanup entries that'll never run

### DIFF
--- a/cron_test.go
+++ b/cron_test.go
@@ -149,6 +149,25 @@ func TestSnapshotEntries(t *testing.T) {
 
 }
 
+// fixedTimeSchedule is a Schedule implementation that must be run at a
+// specific point in time.
+type fixedTimeSchedule time.Time
+
+func (fs fixedTimeSchedule) Next(t time.Time) time.Time {
+	return time.Time(fs)
+}
+
+// Test cleaning up of unsatisfiable entries.
+func TestCleanup(t *testing.T) {
+	cron := New()
+	cron.AddFunc("* * * * * *", func() {})
+	cron.Schedule(fixedTimeSchedule{}, FuncJob(func() {}))
+	cron.Cleanup()
+	if len(cron.Entries()) != 1 {
+		t.Error("Cleanup did not remove entry")
+	}
+}
+
 // Test that the entries are correctly sorted.
 // Add a bunch of long-in-the-future entries, and an immediate entry, and ensure
 // that the immediate entry runs immediately.


### PR DESCRIPTION
When this package is used in a service, it's useful to be able to remove
jobs that are not required anymore.

Since the package does not provide a way to remove a specific entry,
this change adds a method to remove entries that'll never get run in
future.  With this change Schedule implementations can return a
zero-time from Next(), and such entries can be removed from Cron.