### PR TITLE
mv cron log to an interface

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -1,7 +1,6 @@
 package cron
 
 import (
-	"log"
 	"runtime"
 	"sort"
 	"time"
@@ -16,7 +15,7 @@ type Cron struct {
 	add      chan *Entry
 	snapshot chan []*Entry
 	running  bool
-	ErrorLog *log.Logger
+	ErrorLog Logger
 	location *time.Location
 }
 
@@ -81,7 +80,7 @@ func NewWithLocation(location *time.Location) *Cron {
 		stop:     make(chan struct{}),
 		snapshot: make(chan []*Entry),
 		running:  false,
-		ErrorLog: nil,
+		ErrorLog: newStdOutLogger(),
 		location: location,
 	}
 }
@@ -223,11 +222,7 @@ func (c *Cron) run() {
 
 // Logs an error to stderr or to the configured error log
 func (c *Cron) logf(format string, args ...interface{}) {
-	if c.ErrorLog != nil {
-		c.ErrorLog.Printf(format, args...)
-	} else {
-		log.Printf(format, args...)
-	}
+	c.ErrorLog.Logf(format, args...)
 }
 
 // Stop stops the cron scheduler if it is running; otherwise it does nothing.

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,34 @@
+package cron
+
+import "log"
+
+// Logger is the simplest interface for logging
+type Logger interface {
+	Logf(format string, args ...interface{})
+}
+
+// NewStandartLogger returns a "Logger" wrapper for the standard go-logger;
+// it should help to migrate to the interface
+func NewStandartLogger(logger *log.Logger) *StandardLogger {
+	return &StandardLogger{logger}
+}
+
+// StandardLogger allows to pass all work to the standard go-logger
+type StandardLogger struct {
+	logger *log.Logger
+}
+
+// Logf just passes params to the standard go-logger
+func (l *StandardLogger) Logf(format string, args ...interface{}) {
+	l.logger.Printf(format, args...)
+}
+
+func newStdOutLogger() *stdOutLogger {
+	return &stdOutLogger{}
+}
+
+type stdOutLogger struct{}
+
+func (l *stdOutLogger) Logf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}


### PR DESCRIPTION
This's a neat cron package. 

But we need to handle job panic messages with our custom logger, because default multiline stdout breaks our logstash/kibana setup. So I tried to add more flexibility with interface and keep an old behavior.