### PR TITLE
Add support to named jobs

### DIFF
--- a/cron_test.go
+++ b/cron_test.go
@@ -397,6 +397,20 @@ func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	}
 }
 
+// Tests that named jobs are correctly registered
+func TestNamedJob(t *testing.T) {
+	cron := New()
+	cron.AddNamedFunc("* * * * * *", "job1", func() {})
+	jobs := cron.Entries()
+	count := len(jobs)
+	if count != 1 {
+		t.Errorf("Expected 1 job. Got %d.\n", count)
+	}
+	if jobs[0].Name != "job1" {
+		t.Errorf("Expected job name to be 'job1'. Got %s.\n", jobs[0].Name)
+	}
+}
+
 func wait(wg *sync.WaitGroup) chan bool {
 	ch := make(chan bool)
 	go func() {

--- a/doc.go
+++ b/doc.go
@@ -10,6 +10,8 @@ them in their own goroutines.
 	c.AddFunc("0 30 * * * *", func() { fmt.Println("Every hour on the half hour") })
 	c.AddFunc("@hourly",      func() { fmt.Println("Every hour") })
 	c.AddFunc("@every 1h30m", func() { fmt.Println("Every hour thirty") })
+	// Functions may have a name
+	c.AddNamedFunc("@every 27m", "Every 27 minutes", func() { fmt.Println("Every 27 minutes")})
 	c.Start()
 	..
 	// Funcs are invoked in their own goroutine, asynchronously.
@@ -84,7 +86,7 @@ You may use one of several pre-defined schedules in place of a cron expression.
 
 Intervals
 
-You may also schedule a job to execute at fixed intervals, starting at the time it's added 
+You may also schedule a job to execute at fixed intervals, starting at the time it's added
 or cron is run. This is supported by formatting the cron spec like this:
 
     @every <duration>


### PR DESCRIPTION
This adds supports to named functions without breaking compatibility with the current API. This way, inspecting jobs and when they were/will be executed is easier.

The API expect the same arguments as `AddFunc`, except for an extra `name` parameter taken before the job function.
```go
c.AddNamedFunc("@every 1m", "Every 1 minute", func() { fmt.Println("Every 1 minute") })
```