### PR TITLE
Fix Data race with Cron.running

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"runtime"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -11,13 +12,14 @@ import (
 // specified by the schedule. It may be started, stopped, and the entries may
 // be inspected while running.
 type Cron struct {
-	entries  []*Entry
-	stop     chan struct{}
-	add      chan *Entry
-	snapshot chan []*Entry
-	running  bool
-	ErrorLog *log.Logger
-	location *time.Location
+	entries     []*Entry
+	stop        chan struct{}
+	add         chan *Entry
+	snapshot    chan []*Entry
+	runningLock sync.Mutex
+	running     bool
+	ErrorLog    *log.Logger
+	location    *time.Location
 }
 
 // Job is an interface for submitted cron jobs.
@@ -112,6 +114,8 @@ func (c *Cron) Schedule(schedule Schedule, cmd Job) {
 		Schedule: schedule,
 		Job:      cmd,
 	}
+	c.runningLock.Lock()
+	defer c.runningLock.Unlock()
 	if !c.running {
 		c.entries = append(c.entries, entry)
 		return
@@ -122,6 +126,8 @@ func (c *Cron) Schedule(schedule Schedule, cmd Job) {
 
 // Entries returns a snapshot of the cron entries.
 func (c *Cron) Entries() []*Entry {
+	c.runningLock.Lock()
+	defer c.runningLock.Unlock()
 	if c.running {
 		c.snapshot <- nil
 		x := <-c.snapshot
@@ -137,19 +143,25 @@ func (c *Cron) Location() *time.Location {
 
 // Start the cron scheduler in its own go-routine, or no-op if already started.
 func (c *Cron) Start() {
+	c.runningLock.Lock()
 	if c.running {
+		c.runningLock.Unlock()
 		return
 	}
 	c.running = true
+	c.runningLock.Unlock()
 	go c.run()
 }
 
 // Run the cron scheduler, or no-op if already running.
 func (c *Cron) Run() {
+	c.runningLock.Lock()
 	if c.running {
+		c.runningLock.Unlock()
 		return
 	}
 	c.running = true
+	c.runningLock.Unlock()
 	c.run()
 }
 
@@ -232,6 +244,8 @@ func (c *Cron) logf(format string, args ...interface{}) {
 
 // Stop stops the cron scheduler if it is running; otherwise it does nothing.
 func (c *Cron) Stop() {
+	c.runningLock.Lock()
+	defer c.runningLock.Unlock()
 	if !c.running {
 		return
 	}


### PR DESCRIPTION
- Fixed a data race issue in `cron.go`. The `running` field was not thread safe.
- Added unit test to check data race fix.
- Also fixed data race issues in unit tests.
- This also fixed the issue in PR #171 (https://github.com/robfig/cron/pull/171)
- run tests with the `-race` options to duplicate