### PR TITLE
Add go.mod for go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/robfig/cron

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/robfig/cron
+module github.com/kolorful/cron


### PR DESCRIPTION
Since the library itself doesn't depend on any 3rd party library, we only need to define the module.