### PR TITLE
Add go.mod for go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/robfig/cron


### PR DESCRIPTION
Since the library itself doesn't depend on any 3rd party library, we only need to define the module.

Once merged, tag seems need to be in the format like "v1.2.0". I tested format "v1.2" and it gives an error when importing this library.