### PR TITLE
add @interval feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module github.com/robfig/cron
+module github.com/lampScript/cron
+
+go 1.12

--- a/intervaldelay.go
+++ b/intervaldelay.go
@@ -1,31 +1,33 @@
 package cron
 
-import "time"
+import (
+	"time"
+)
 
-// ConstantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
+// IntervalDelaySchedule represents a simple recurring duty cycle, e.g. "Interval 5 minutes".
 // It does not support jobs more frequent than once a second.
-type ConstantDelaySchedule struct {
+type IntervalDelaySchedule struct {
 	Delay time.Duration
 }
 
-// Every returns a crontab Schedule that activates once every duration.
+// Interval returns a crontab Schedule that activates once Interval duration.
 // Delays of less than a second are not supported (will round up to 1 second).
 // Any fields less than a Second are truncated.
-func Every(duration time.Duration) ConstantDelaySchedule {
+func Interval(duration time.Duration) IntervalDelaySchedule {
 	if duration < time.Second {
 		duration = time.Second
 	}
-	return ConstantDelaySchedule{
+	return IntervalDelaySchedule{
 		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
 	}
 }
 
 // Next returns the next time this should be run.
 // This rounds so that the next activation time will be on the second.
-func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+func (schedule IntervalDelaySchedule) Next(t time.Time) time.Time {
 	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
 }
 
-func (schedule ConstantDelaySchedule) Sync() bool {
-	return false
+func (schedule IntervalDelaySchedule) Sync() bool {
+	return true
 }

--- a/parser.go
+++ b/parser.go
@@ -127,7 +127,6 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return &SpecSchedule{
 		Second: second,
 		Minute: minute,
@@ -212,7 +211,6 @@ func getRange(expr string, r bounds) (uint64, error) {
 		singleDigit      = len(lowAndHigh) == 1
 		err              error
 	)
-
 	var extra uint64
 	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
 		start = r.min
@@ -256,6 +254,7 @@ func getRange(expr string, r bounds) (uint64, error) {
 	if start < r.min {
 		return 0, fmt.Errorf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
 	}
+
 	if end > r.max {
 		return 0, fmt.Errorf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
 	}
@@ -368,13 +367,19 @@ func parseDescriptor(descriptor string) (Schedule, error) {
 	}
 
 	const every = "@every "
+	const interval = "@interval "
 	if strings.HasPrefix(descriptor, every) {
 		duration, err := time.ParseDuration(descriptor[len(every):])
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse duration %s: %s", descriptor, err)
 		}
 		return Every(duration), nil
+	} else if strings.HasPrefix(descriptor, interval) {
+		duration, err := time.ParseDuration(descriptor[len(interval):])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse duration %s: %s", descriptor, err)
+		}
+		return Interval(duration), nil
 	}
-
 	return nil, fmt.Errorf("Unrecognized descriptor: %s", descriptor)
 }

--- a/spec.go
+++ b/spec.go
@@ -1,6 +1,8 @@
 package cron
 
-import "time"
+import (
+	"time"
+)
 
 // SpecSchedule specifies a duty cycle (to the second granularity), based on a
 // traditional crontab specification. It is computed initially and stored as bit sets.
@@ -140,8 +142,11 @@ WRAP:
 			goto WRAP
 		}
 	}
-
 	return t
+}
+
+func (s *SpecSchedule) Sync() bool {
+	return false
 }
 
 // dayMatches returns true if the schedule's day-of-week and day-of-month


### PR DESCRIPTION
I add @interval feature like constant delay schedule, but it plus the time while doing the job, so when the time to finish the job is longer than your cycle time, you don't have to worry about multiple goroutines do the same job in the same time.