### PR TITLE
add @interval feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,34 @@
 # cron
 
 Documentation here: https://godoc.org/github.com/robfig/cron
+
+---
+
+```
+添加了 @interval 注解模式，保证每两次定时任务不会重叠执行。
+例如:
+c := cron.New()
+c.AddFunc("@interval 10s", func() {
+		time.Sleep(30 * time.Second)
+		fmt.Println("interval 10 second to do next")
+    })
+c.Start()
+
+
+```
+
+---
+```
+add @interval feature
+Sometimes we want only one job working at the same time, but when the time you cost in once the job is longer than your job interval time, you may have mutilated job working at the same time.
+
+So the @interval schedule can help, each job will be executed at the interval time after the previous job is completed.
+
+e.g.
+c := cron.New()
+c.AddFunc("@interval 10s", func() {
+		time.Sleep(30 * time.Second)
+		fmt.Println("interval 10 second to do next")
+    })
+c.Start()
+```

--- a/constantdelay_test.go
+++ b/constantdelay_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestIntervalDelayNext(t *testing.T) {
+func TestConstantDelayNext(t *testing.T) {
 	tests := []struct {
 		time     string
 		delay    time.Duration

--- a/constantdelay_test.go
+++ b/constantdelay_test.go
@@ -47,6 +47,7 @@ func TestIntervalDelayNext(t *testing.T) {
 	for _, c := range tests {
 		actual := Interval(c.delay).Next(getTime(c.time))
 		expected := getTime(c.expected)
+		t.Logf("actual is %s, expected is %s", actual, expected)
 		if actual != expected {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.delay, expected, actual)
 		}

--- a/cron_test.go
+++ b/cron_test.go
@@ -383,6 +383,10 @@ func (*ZeroSchedule) Next(time.Time) time.Time {
 	return time.Time{}
 }
 
+func (*ZeroSchedule) Sync() bool {
+	return false
+}
+
 // Tests that job without time does not run
 func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	cron := New()

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module github.com/robfig/cron
+module github.com/lampScript/cron
+
+go 1.12

--- a/intervaldelay.go
+++ b/intervaldelay.go
@@ -1,31 +1,33 @@
 package cron
 
-import "time"
+import (
+	"time"
+)
 
-// ConstantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
+// IntervalDelaySchedule represents a simple recurring duty cycle, e.g. "Interval 5 minutes".
 // It does not support jobs more frequent than once a second.
-type ConstantDelaySchedule struct {
+type IntervalDelaySchedule struct {
 	Delay time.Duration
 }
 
-// Every returns a crontab Schedule that activates once every duration.
+// Interval returns a crontab Schedule that activates once Interval duration.
 // Delays of less than a second are not supported (will round up to 1 second).
 // Any fields less than a Second are truncated.
-func Every(duration time.Duration) ConstantDelaySchedule {
+func Interval(duration time.Duration) IntervalDelaySchedule {
 	if duration < time.Second {
 		duration = time.Second
 	}
-	return ConstantDelaySchedule{
+	return IntervalDelaySchedule{
 		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
 	}
 }
 
 // Next returns the next time this should be run.
 // This rounds so that the next activation time will be on the second.
-func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+func (schedule IntervalDelaySchedule) Next(t time.Time) time.Time {
 	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
 }
 
-func (schedule ConstantDelaySchedule) Sync() bool {
-	return false
+func (schedule IntervalDelaySchedule) Sync() bool {
+	return true
 }

--- a/intervaldelay_test.go
+++ b/intervaldelay_test.go
@@ -1,54 +1,56 @@
 package cron
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 )
 
 func TestConstantDelayNext(t *testing.T) {
 	tests := []struct {
-		time     string
-		delay    time.Duration
-		expected string
+		time  string
+		delay time.Duration
 	}{
 		// Simple cases
-		{"Mon Jul 9 14:45 2012", 15*time.Minute + 50*time.Nanosecond, "Mon Jul 9 15:00 2012"},
-		{"Mon Jul 9 14:59 2012", 15 * time.Minute, "Mon Jul 9 15:14 2012"},
-		{"Mon Jul 9 14:59:59 2012", 15 * time.Minute, "Mon Jul 9 15:14:59 2012"},
+		{"Mon Jul 9 14:45 2012", 15*time.Minute + 50*time.Nanosecond},
+		{"Mon Jul 9 14:59 2012", 15 * time.Minute},
+		{"Mon Jul 9 14:59:59 2012", 15 * time.Minute},
 
 		// Wrap around hours
-		{"Mon Jul 9 15:45 2012", 35 * time.Minute, "Mon Jul 9 16:20 2012"},
+		{"Mon Jul 9 15:45 2012", 35 * time.Minute},
 
 		// Wrap around days
-		{"Mon Jul 9 23:46 2012", 14 * time.Minute, "Tue Jul 10 00:00 2012"},
-		{"Mon Jul 9 23:45 2012", 35 * time.Minute, "Tue Jul 10 00:20 2012"},
-		{"Mon Jul 9 23:35:51 2012", 44*time.Minute + 24*time.Second, "Tue Jul 10 00:20:15 2012"},
-		{"Mon Jul 9 23:35:51 2012", 25*time.Hour + 44*time.Minute + 24*time.Second, "Thu Jul 11 01:20:15 2012"},
+		{"Mon Jul 9 23:46 2012", 14 * time.Minute},
+		{"Mon Jul 9 23:45 2012", 35 * time.Minute},
+		{"Mon Jul 9 23:35:51 2012", 44*time.Minute + 24*time.Second},
+		{"Mon Jul 9 23:35:51 2012", 25*time.Hour + 44*time.Minute + 24*time.Second},
 
 		// Wrap around months
-		{"Mon Jul 9 23:35 2012", 91*24*time.Hour + 25*time.Minute, "Thu Oct 9 00:00 2012"},
+		{"Mon Jul 9 23:35 2012", 91*24*time.Hour + 25*time.Minute},
 
 		// Wrap around minute, hour, day, month, and year
-		{"Mon Dec 31 23:59:45 2012", 15 * time.Second, "Tue Jan 1 00:00:00 2013"},
+		{"Mon Dec 31 23:59:45 2012", 15 * time.Second},
 
 		// Round to nearest second on the delay
-		{"Mon Jul 9 14:45 2012", 15*time.Minute + 50*time.Nanosecond, "Mon Jul 9 15:00 2012"},
+		{"Mon Jul 9 14:45 2012", 15*time.Minute + 50*time.Nanosecond},
 
 		// Round up to 1 second if the duration is less.
-		{"Mon Jul 9 14:45:00 2012", 15 * time.Millisecond, "Mon Jul 9 14:45:01 2012"},
+		{"Mon Jul 9 14:45:00 2012", 15 * time.Millisecond},
 
 		// Round to nearest second when calculating the next time.
-		{"Mon Jul 9 14:45:00.005 2012", 15 * time.Minute, "Mon Jul 9 15:00 2012"},
+		{"Mon Jul 9 14:45:00.005 2012", 15 * time.Minute},
 
 		// Round to nearest second for both.
-		{"Mon Jul 9 14:45:00.005 2012", 15*time.Minute + 50*time.Nanosecond, "Mon Jul 9 15:00 2012"},
+		{"Mon Jul 9 14:45:00.005 2012", 15*time.Minute + 50*time.Nanosecond},
 	}
 
-	for _, c := range tests {
-		actual := Interval(c.delay).Next(getTime(c.time))
-		expected := getTime(c.expected)
+	for i, c := range tests {
+		jobCostTime := time.Duration(rand.Intn(5)) * time.Second
+		Schedule := Interval(c.delay)
+		actual := Schedule.Next(getTime(c.time).Add(jobCostTime))
+		expected := getTime(c.time).Add(Schedule.Delay).Add(jobCostTime)
 		if actual != expected {
-			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.delay, expected, actual)
+			t.Errorf("case %d : %s, \"%s\": (expected) %v != %v (actual)", i, c.time, c.delay, expected, actual)
 		}
 	}
 }

--- a/intervaldelay_test.go
+++ b/intervaldelay_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestIntervalDelayNext(t *testing.T) {
+func TestConstantDelayNext(t *testing.T) {
 	tests := []struct {
 		time     string
 		delay    time.Duration

--- a/parser.go
+++ b/parser.go
@@ -127,7 +127,6 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return &SpecSchedule{
 		Second: second,
 		Minute: minute,
@@ -212,7 +211,6 @@ func getRange(expr string, r bounds) (uint64, error) {
 		singleDigit      = len(lowAndHigh) == 1
 		err              error
 	)
-
 	var extra uint64
 	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
 		start = r.min
@@ -256,6 +254,7 @@ func getRange(expr string, r bounds) (uint64, error) {
 	if start < r.min {
 		return 0, fmt.Errorf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
 	}
+
 	if end > r.max {
 		return 0, fmt.Errorf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
 	}
@@ -368,13 +367,19 @@ func parseDescriptor(descriptor string) (Schedule, error) {
 	}
 
 	const every = "@every "
+	const interval = "@interval "
 	if strings.HasPrefix(descriptor, every) {
 		duration, err := time.ParseDuration(descriptor[len(every):])
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse duration %s: %s", descriptor, err)
 		}
 		return Every(duration), nil
+	} else if strings.HasPrefix(descriptor, interval) {
+		duration, err := time.ParseDuration(descriptor[len(interval):])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse duration %s: %s", descriptor, err)
+		}
+		return Interval(duration), nil
 	}
-
 	return nil, fmt.Errorf("Unrecognized descriptor: %s", descriptor)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -179,6 +179,10 @@ func TestParse(t *testing.T) {
 			expr: "",
 			err:  "Empty spec string",
 		},
+		{
+			expr:     "@interval 5m",
+			expected: IntervalDelaySchedule{Delay: time.Duration(5) * time.Minute},
+		},
 	}
 
 	for _, c := range entries {

--- a/spec.go
+++ b/spec.go
@@ -1,6 +1,8 @@
 package cron
 
-import "time"
+import (
+	"time"
+)
 
 // SpecSchedule specifies a duty cycle (to the second granularity), based on a
 // traditional crontab specification. It is computed initially and stored as bit sets.
@@ -140,8 +142,11 @@ WRAP:
 			goto WRAP
 		}
 	}
-
 	return t
+}
+
+func (s *SpecSchedule) Sync() bool {
+	return false
 }
 
 // dayMatches returns true if the schedule's day-of-week and day-of-month


### PR DESCRIPTION
Sometimes we want only one job working at the same time, but when the time you cost in once the job is longer than your job interval time, you may have mutilated job working at the same time. 

So the @interval schedule can help, each job will be executed at the interval time after the previous job is completed.