### PR TITLE
Fix data race in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: go
+
+sudo: false
+
+script:
+  - go vet
+  - go build
+  - go test -race -cover

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/robfig/cron
+
+go 1.12


### PR DESCRIPTION
This change fixes 2 small data races on TestAddWhileRunningWithDelay and TestJobWithZeroTimeDoesNotRun in cron_test.go.


