### PR TITLE
Introduce CRON which run end of every month

### DIFF
--- a/endofmonth.go
+++ b/endofmonth.go
@@ -1,0 +1,68 @@
+package cron
+
+import "time"
+
+// EomSchedule represents a simple recurring cycle which runs on
+// last day(00:00:00.000) of every month
+type EomSchedule struct {
+	// Override location for this schedule.
+	Location *time.Location
+}
+
+// Last day of every month
+var monthEndDay = map[time.Month]int{
+	time.January:   31,
+	time.February:  28,
+	time.March:     31,
+	time.April:     30,
+	time.May:       31,
+	time.June:      30,
+	time.July:      31,
+	time.August:    31,
+	time.September: 30,
+	time.October:   31,
+	time.November:  30,
+	time.December:  31,
+}
+
+// Next returns the next time this should be run.
+// Returns last day of the month if possible, or switches over to the next month
+func (schedule EomSchedule) Next(t time.Time) time.Time {
+	month := t.Month()
+	year := t.Year()
+	currentMonthEndDay := fetchMonthEndDay(month, year)
+
+	if t.Day() >= currentMonthEndDay {
+		if month == time.December {
+			return time.Date(year+1, time.January, fetchMonthEndDay(month, year), 0, 0, 0, 0, schedule.Location)
+		}
+
+		nextMonth := t.Month() + 1
+		day := fetchMonthEndDay(nextMonth, year)
+
+		return time.Date(year, nextMonth, day, 0, 0, 0, 0, schedule.Location)
+	}
+
+	return time.Date(year, t.Month(), currentMonthEndDay, 0, 0, 0, 0, schedule.Location)
+}
+
+// isLeapYear returns true if the given year is a leap year
+func isLeapYear(year int) bool {
+	if year%400 == 0 {
+		return true
+	} else if year%100 == 0 {
+		return false
+	} else if year%4 == 0 {
+		return true
+	}
+	return false
+}
+
+// fetchMonthEndDay returns the last day of the month,
+// for the given month and year
+func fetchMonthEndDay(m time.Month, y int) int {
+	if m == time.February && isLeapYear(y) {
+		return 29
+	}
+	return monthEndDay[m]
+}

--- a/endofmonth_test.go
+++ b/endofmonth_test.go
@@ -1,0 +1,30 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEomNext(t *testing.T) {
+	tests := []struct {
+		time     time.Time
+		expected time.Time
+	}{
+		{time.Date(2019, time.January, 20, 0, 0, 0, 0, time.Local), time.Date(2019, time.January, 31, 0, 0, 0, 0, time.Local)},
+		{time.Date(2019, time.January, 31, 0, 0, 0, 0, time.Local), time.Date(2019, time.February, 28, 0, 0, 0, 0, time.Local)},
+		{time.Date(2019, time.December, 31, 1, 12, 31, 312, time.Local), time.Date(2020, time.January, 31, 0, 0, 0, 0, time.Local)},
+		{time.Date(2019, time.May, 31, 1, 12, 31, 312, time.Local), time.Date(2019, time.June, 30, 0, 0, 0, 0, time.Local)},
+		{time.Date(2020, time.February, 13, 1, 12, 49, 312, time.Local), time.Date(2020, time.February, 29, 0, 0, 0, 0, time.Local)},
+	}
+
+	for _, c := range tests {
+		testSchedule := EomSchedule{
+			time.Local,
+		}
+		actual := testSchedule.Next(c.time)
+		expected := c.expected
+		if actual != expected {
+			t.Errorf("(expected) %v != %v (actual)", expected, actual)
+		}
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -419,6 +419,10 @@ func parseDescriptor(descriptor string, loc *time.Location) (Schedule, error) {
 			Location: loc,
 		}, nil
 
+	case "@eom":
+		return &EomSchedule{
+			Location: loc,
+		}, nil
 	}
 
 	const every = "@every "

--- a/parser_test.go
+++ b/parser_test.go
@@ -168,6 +168,7 @@ func TestParseSchedule(t *testing.T) {
 				Location: time.Local,
 			},
 		},
+		{secondParser, "@eom", &EomSchedule{Location: time.Local}},
 	}
 
 	for _, c := range entries {


### PR DESCRIPTION
We have introduced a new descriptor `@eom`, which basically runs the job during the beginning hour of the last day of every month

Usage:
```go
cron.New().AddFunc("@eom", ...)
```

Sample use cases:

- Processing payroll related stuff
- Scheduled monthly reports

Kindly review the PR and provide your inputs.

Possible enhancements in mind:

- Configuring run time(Min, Hour, Dow) along with the descriptor
  `@eom 45 8 FRI`


Co-authored-by: dineshba <dineshudt17@gmail.com>