### PR TITLE
Let cron depend on interface for parsers instead of fixed parser

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -21,9 +21,14 @@ type Cron struct {
 	logger    Logger
 	runningMu sync.Mutex
 	location  *time.Location
-	parser    Parser
+	parser    ScheduleParser
 	nextID    EntryID
 	jobWaiter sync.WaitGroup
+}
+
+// ScheduleParser is an interface for schedule spec parsers that return a Schedule
+type ScheduleParser interface {
+	Parse(spec string) (Schedule, error)
 }
 
 // Job is an interface for submitted cron jobs.

--- a/option.go
+++ b/option.go
@@ -23,7 +23,7 @@ func WithSeconds() Option {
 }
 
 // WithParser overrides the parser used for interpreting job schedules.
-func WithParser(p Parser) Option {
+func WithParser(p ScheduleParser) Option {
 	return func(c *Cron) {
 		c.parser = p
 	}


### PR DESCRIPTION
This change allows cron to use another or extended parser instead of the one that comes in the package.