### PR TITLE
Fix channel scoping in chain.SkipIfStillRunning

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -76,9 +76,10 @@ func DelayIfStillRunning(logger Logger) JobWrapper {
 // SkipIfStillRunning skips an invocation of the Job if a previous invocation is
 // still running. It logs skips to the given logger at Info level.
 func SkipIfStillRunning(logger Logger) JobWrapper {
-	var ch = make(chan struct{}, 1)
-	ch <- struct{}{}
 	return func(j Job) Job {
+		var ch = make(chan struct{}, 1)
+		ch <- struct{}{}
+
 		return FuncJob(func() {
 			select {
 			case v := <-ch:


### PR DESCRIPTION
This change fixes the scoping of the channel used for skipping jobs in SkipIfStillRunning middleware, which led to incorrectly skipping all-1 tasks added at the same time.