### PR TITLE
update cron schedule

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -14,7 +14,7 @@ import (
 // be inspected while running.
 type Cron struct {
 	entries []*Entry
-	// entriesLookupTable can be used for constant time lookup to fetch entry.
+	// entriesLookupTable can be used for constant time lookup of entries.
 	entryLookupTable map[EntryID]*Entry
 	chain            Chain
 	stop             chan struct{}
@@ -372,7 +372,7 @@ func (c *Cron) addNewEntry(entry *Entry) {
 }
 
 // removeEntry removes the entry corresponding to the given ID from the entry list as
-// we as the entryLookupTable.
+// well as the entryLookupTable.
 func (c *Cron) removeEntry(id EntryID) {
 	var entries []*Entry
 	for _, e := range c.entries {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/robfig/cron/v3
 
 go 1.12
+
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.4.0
+)


### PR DESCRIPTION
Added a function Cron.UpdateSchedule(id, spec) that can be used
to update the schedule of the cron job associated with the given id.
The following changes/additions were made.
1. To allow for constant time lookup, added a new member to Cron.
	entryLookupTable map[EntryID]*Entry

2. Added a new function, addNewEntry(*Entry) that not only appends
the entry to the list of entries but also adds it to the
entryLookupTable.

3. Retrofitted Cron.Schedule() and Cron.run() to now use
Cron.addNewEntry() instead of directly appending Cron.entries.

4. Retrofitted Cron.removeEntry() to also delete the entry from
entryLookupTable.

Added test coverage for cron.UpdateSchedule(id, spec).
The following tests were added.
1. Update the schedule without calling cron.Start() and verify if
the schedule interval changed.
2. Update the schedule while the cron job is running (after calling
cron.Start()) and verify if the schedule interval changed.