### PR TITLE
strip monotonic clock

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -62,7 +62,7 @@ func DelayIfStillRunning(logger Logger) JobWrapper {
 	return func(j Job) Job {
 		var mu sync.Mutex
 		return FuncJob(func() {
-			start := time.Now()
+			start := time.Now().Round(0)
 			mu.Lock()
 			defer mu.Unlock()
 			if dur := time.Since(start); dur > time.Minute {

--- a/cron.go
+++ b/cron.go
@@ -315,7 +315,7 @@ func (c *Cron) startJob(j Job) {
 
 // now returns current time in c location
 func (c *Cron) now() time.Time {
-	return time.Now().In(c.location)
+	return time.Now().Round(0).In(c.location)
 }
 
 // Stop stops the cron scheduler if it is running; otherwise it does nothing.


### PR DESCRIPTION
> https://golang.org/pkg/time/#hdr-Monotonic_Clocks

Use monotonic clock may not accurately measure elapsed time.
