### PR TITLE
Scedule Previous method implementation

### DIFF
--- a/constantdelay.go
+++ b/constantdelay.go
@@ -25,3 +25,9 @@ func Every(duration time.Duration) ConstantDelaySchedule {
 func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
 	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
 }
+
+// Previous returns the last time this should have been be run.
+// This rounds so that the previous activation time will be on the last second.
+func (schedule ConstantDelaySchedule) Previous(t time.Time) time.Time {
+	return t.Add(-schedule.Delay + time.Duration(t.Nanosecond())*time.Nanosecond)
+}

--- a/constantdelay.go
+++ b/constantdelay.go
@@ -26,7 +26,7 @@ func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
 	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
 }
 
-// Previous returns the last time this should have been be run.
+// Previous returns the last time this should have been run.
 // This rounds so that the previous activation time will be on the last second.
 func (schedule ConstantDelaySchedule) Previous(t time.Time) time.Time {
 	return t.Add(-schedule.Delay + time.Duration(t.Nanosecond())*time.Nanosecond)

--- a/cron.go
+++ b/cron.go
@@ -41,6 +41,8 @@ type Schedule interface {
 	// Next returns the next activation time, later than the given time.
 	// Next is invoked initially, and then each time the job is run.
 	Next(time.Time) time.Time
+	// Previous returns the previous activation time, lower than the given time.
+	Previous(time.Time) time.Time
 }
 
 // EntryID identifies an entry within a Cron instance

--- a/cron_test.go
+++ b/cron_test.go
@@ -541,6 +541,10 @@ func (*ZeroSchedule) Next(time.Time) time.Time {
 	return time.Time{}
 }
 
+func (*ZeroSchedule) Previous(time.Time) time.Time {
+	return time.Time{}
+}
+
 // Tests that job without time does not run
 func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	cron := newWithSeconds()

--- a/spec.go
+++ b/spec.go
@@ -174,6 +174,110 @@ WRAP:
 	return t.In(origLocation)
 }
 
+// Previous returns the previous time this schedule would have been activated, lower than the given
+// time.  If no time can be found to satisfy the schedule, return the zero time.
+func (s *SpecSchedule) Previous(t time.Time) time.Time {
+	// General approach
+	//
+	// For Month, Day, Hour, Minute, Second:
+	// Check if the time value matches.  If yes, continue to the next field.
+	// If the field doesn't match the schedule, then decrement the field until it matches.
+	// While decrementing the field, a wrap-around brings it back to the beginning
+	// of the field list (since it is necessary to re-verify previous field
+	// values)
+
+	// Convert the given time into the schedule's timezone, if one is specified.
+	// Save the original timezone so we can convert back after we find a time.
+	// Note that schedules without a time zone specified (time.Local) are treated
+	// as local to the time provided.
+	origLocation := t.Location()
+	loc := s.Location
+	if loc == time.Local {
+		loc = t.Location()
+	}
+	if s.Location != time.Local {
+		t = t.In(s.Location)
+	}
+
+	// Start at the earliest possible time (the previous second).
+	t = t.Add(-1*time.Second - time.Duration(t.Nanosecond())*time.Nanosecond)
+
+	// This flag indicates whether a field has been decremented.
+	subtracted := false
+
+	// If no time is found within five years, return zero.
+	yearLimit := t.Year() - 5
+
+WRAP:
+	if t.Year() < yearLimit {
+		return time.Time{}
+	}
+
+	// Find the first applicable month.
+	// If it's this month, then do nothing.
+	for 1<<uint(t.Month())&s.Month == 0 {
+		// If we have to subtract a month, reset the other parts to 0.
+		subtracted = true
+		t = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, loc).Add(-time.Second)
+
+		// Wrapped around.
+		if t.Month() == time.December {
+			goto WRAP
+		}
+	}
+
+	// Now get a day in that month.
+	for !dayMatches(s, t) {
+		if !subtracted {
+			subtracted = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1).Add(-time.Second)
+		}
+		t = t.AddDate(0, 0, -1)
+
+		if t.AddDate(0, 0, 1).Day() == 1 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Hour())&s.Hour == 0 {
+		if !subtracted {
+			subtracted = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, loc).Add(time.Hour).Add(-time.Second)
+		}
+		t = t.Add(-1 * time.Hour)
+
+		if t.Hour() == 23 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Minute())&s.Minute == 0 {
+		if !subtracted {
+			subtracted = true
+			t = t.Truncate(time.Minute).Add(time.Minute).Add(-time.Second)
+		}
+		t = t.Add(-1 * time.Minute)
+
+		if t.Minute() == 59 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Second())&s.Second == 0 {
+		if !subtracted {
+			subtracted = true
+			t = t.Truncate(time.Second).Add(time.Second)
+		}
+		t = t.Add(-1 * time.Second)
+
+		if t.Second() == 59 {
+			goto WRAP
+		}
+	}
+
+	return t.In(origLocation)
+}
+
 // dayMatches returns true if the schedule's day-of-week and day-of-month
 // restrictions are satisfied by the given time.
 func dayMatches(s *SpecSchedule, t time.Time) bool {

--- a/spec_test.go
+++ b/spec_test.go
@@ -199,6 +199,138 @@ func TestNext(t *testing.T) {
 	}
 }
 
+func TestPrevious(t *testing.T) {
+	runs := []struct {
+		time, spec string
+		expected   string
+	}{
+		// Simple cases
+		{"Mon Jul 9 15:15 2012", "0 0/15 * * * *", "Mon Jul 9 15:00 2012"},
+		{"Mon Jul 9 15:01 2012", "0 0/15 * * * *", "Mon Jul 9 15:00 2012"},
+		{"Mon Jul 9 15:00:01 2012", "0 0/15 * * * *", "Mon Jul 9 15:00 2012"},
+
+		// // Wrap around hours
+		{"Mon Jul 9 15:20 2012", "0 20-35/15 * * * *", "Mon Jul 9 14:35 2012"},
+
+		// // Wrap around days
+		{"Mon Jul 9 00:00 2012", "0 */15 * * * *", "Sun Jul 8 23:45 2012"},
+		{"Mon Jul 9 00:15 2012", "0 20-35/15 * * * *", "Sun Jul 8 23:35 2012"},
+		{"Mon Jul 9 00:15:19 2012", "15/35 20-35/15 * * * *", "Sun Jul 8 23:35:50 2012"},
+		{"Mon Jul 9 00:15:19 2012", "15/35 20-35/15 */2 * * *", "Sun Jul 8 22:35:50 2012"},
+		{"Mon Jul 9 00:15:19 2012", "15/35 20-35/15 10-12 * * *", "Sun Jul 8 12:35:50 2012"},
+
+		{"Mon Jul 9 00:15:19 2012", "15/35 20-35/15 1/2 */2 * *", "Sat Jul 7 23:35:50 2012"},
+		{"Mon Jul 9 00:15:19 2012", "15/35 20-35/15 * 9-20 * *", "Wed Jun 20 23:35:50 2012"},
+		{"Mon Jul 9 00:15:19 2012", "15/35 20-35/15 * 9-20 Jul *", "Wed Jul 20 23:35:50 2011"},
+
+		// Wrap around months
+		{"Mon Jul 9 00:15:19 2012", "0 0 0 9 Apr-Oct ?", "Thu Jul 9 00:00 2012"},
+		{"Mon Jul 9 00:15:19 2012", "0 0 0 */5 Apr,Aug,Oct Thu", "Thu Apr 26 00:00 2012"},
+		{"Mon Jul 9 00:15:19 2012", "0 0 0 */5 Jun Mon", "Mon Jun 26 00:00 2012"},
+
+		// Wrap around years
+		{"Mon Jul 9 00:15:19 2012", "0 0 0 */5 Oct Mon", "Mon Oct 31 00:00 2011"},
+		{"Mon Jul 9 00:15:19 2012", "0 0 0 * Oct Mon/2", "Mon Oct 31 00:00 2011"},
+
+		// Wrap around minute, hour, day, month, and year
+		{"Tue Jan 1 00:00:00 2013", "0 * * * * *", "Mon Dec 31 23:59:00 2012"},
+
+		// Leap year
+		{"Mon Jul 9 00:15:19 2011", "0 0 0 29 Feb ?", "Fri Feb 29 00:00 2008"},
+
+		// Daylight savings time 2am EST (-5) -> 3am EDT (-4)
+		{"2012-03-11T03:00:00-0400", "TZ=America/New_York 0 30 2 11 Mar ?", "2011-03-11T02:30:00-0500"},
+
+		// hourly job
+		{"2012-03-11T05:00:00-0400", "TZ=America/New_York 0 0 * * * ?", "2012-03-11T04:00:00-0400"},
+		{"2012-03-11T04:00:00-0400", "TZ=America/New_York 0 0 * * * ?", "2012-03-11T02:00:00-0500"},
+		{"2012-03-11T02:00:00-0400", "TZ=America/New_York 0 0 * * * ?", "2012-03-11T01:00:00-0400"},
+		{"2012-03-11T01:00:00-0500", "TZ=America/New_York 0 0 * * * ?", "2012-03-11T00:00:00-0500"},
+
+		// hourly job using CRON_TZ
+		{"2012-03-11T05:00:00-0400", "CRON_TZ=America/New_York 0 0 * * * ?", "2012-03-11T04:00:00-0400"},
+		{"2012-03-11T04:00:00-0400", "CRON_TZ=America/New_York 0 0 * * * ?", "2012-03-11T03:00:00-0400"},
+		{"2012-03-11T03:00:00-0400", "CRON_TZ=America/New_York 0 0 * * * ?", "2012-03-11T01:00:00-0500"},
+		{"2012-03-11T01:00:00-0500", "CRON_TZ=America/New_York 0 0 * * * ?", "2012-03-11T00:00:00-0500"},
+
+		// 1am nightly job
+		{"2012-03-11T01:00:00-0500", "TZ=America/New_York 0 0 1 * * ?", "2012-03-10T01:00:00-0500"},
+		{"2012-03-12T01:00:00-0400", "TZ=America/New_York 0 0 1 * * ?", "2012-03-11T01:00:00-0500"},
+
+		// 2am nightly job (skipped)
+		{"2012-03-11T03:00:00-0400", "TZ=America/New_York 0 0 2 * * ?", "2012-03-10T02:00:00-0500"},
+
+		// Daylight savings time 2am EDT (-4) => 1am EST (-5)
+		{"2012-11-04T03:00:00-0400", "TZ=America/New_York 0 30 1 04 Nov ?", "2012-11-04T01:30:00-0500"},
+
+		// hourly job
+		{"2012-11-04T01:00:00-0400", "TZ=America/New_York 0 0 * * * ?", "2012-11-04T00:00:00-0400"},
+		{"2012-11-04T01:00:00-0500", "TZ=America/New_York 0 0 * * * ?", "2012-11-04T01:00:00-0400"},
+		{"2012-11-04T02:00:00-0500", "TZ=America/New_York 0 0 * * * ?", "2012-11-04T01:00:00-0500"},
+
+		// 1am nightly job (runs twice)
+		{"2012-11-04T02:00:00-0500", "TZ=America/New_York 0 0 1 * * ?", "2012-11-04T01:00:00-0500"},
+		{"2012-11-04T01:00:00-0500", "TZ=America/New_York 0 0 1 * * ?", "2012-11-04T01:00:00-0400"},
+		{"2012-11-04T02:00:00-0400", "TZ=America/New_York 0 0 1 * * ?", "2012-11-04T01:00:00-0400"},
+
+		// 2am nightly job
+		{"2012-11-04T03:00:00-0500", "TZ=America/New_York 0 0 2 * * ?", "2012-11-04T02:00:00-0500"},
+		{"2012-11-04T02:00:00-0400", "TZ=America/New_York 0 0 2 * * ?", "2012-11-03T02:00:00-0400"},
+
+		// 3am nightly job
+		{"2012-11-04T04:00:00-0500", "TZ=America/New_York 0 0 3 * * ?", "2012-11-04T03:00:00-0500"},
+		{"2012-11-04T03:00:00-0500", "TZ=America/New_York 0 0 3 * * ?", "2012-11-03T03:00:00-0400"},
+
+		// hourly job
+		{"TZ=America/New_York 2012-11-04T03:00:00-0500", "0 0 * * * ?", "2012-11-04T02:00:00-0500"},
+		{"TZ=America/New_York 2012-11-04T02:00:00-0500", "0 0 * * * ?", "2012-11-04T02:00:00-0400"},
+		{"TZ=America/New_York 2012-11-04T02:00:00-0400", "0 0 * * * ?", "2012-11-04T01:00:00-0400"},
+
+		// 1am nightly job (runs twice)
+		{"TZ=America/New_York 2012-11-04T03:00:00-0500", "0 0 1 * * ?", "2012-11-04T01:00:00-0500"},
+		{"TZ=America/New_York 2012-11-04T02:00:00-0500", "0 0 1 * * ?", "2012-11-04T01:00:00-0500"},
+		{"TZ=America/New_York 2012-11-04T01:00:00-0500", "0 0 1 * * ?", "2012-11-04T01:00:00-0400"},
+		{"TZ=America/New_York 2012-11-04T01:00:00-0400", "0 0 1 * * ?", "2012-11-03T01:00:00-0400"},
+
+		// 2am nightly job
+		{"TZ=America/New_York 2012-11-04T03:00:00-0500", "0 0 2 * * ?", "2012-11-04T02:00:00-0500"},
+		{"TZ=America/New_York 2012-11-04T02:00:00-0500", "0 0 2 * * ?", "2012-11-03T02:00:00-0400"},
+
+		// 3am nightly job
+		{"TZ=America/New_York 2012-11-04T04:00:00-0500", "0 0 3 * * ?", "2012-11-04T03:00:00-0500"},
+		{"TZ=America/New_York 2012-11-04T03:00:00-0500", "0 0 3 * * ?", "2012-11-03T03:00:00-0400"},
+
+		// Unsatisfiable
+		{"Mon Jul 9 23:35 2012", "0 0 0 30 Feb ?", ""},
+		{"Mon Jul 9 23:35 2012", "0 0 0 31 Apr ?", ""},
+
+		// Monthly job
+		{"TZ=America/New_York 2012-12-02T00:00:00-0500", "0 0 1 3 * ?", "2012-11-03T01:00:00-0400"},
+
+		// Test the scenario of DST resulting in midnight not being a valid time.
+		// https://github.com/robfig/cron/issues/157
+		{"2018-02-18T01:00:00-0300", "TZ=America/Sao_Paulo 0 0 9 * * ?", "2018-02-17T09:00:00-0200"},
+		{"2018-02-18T00:00:00-0300", "TZ=America/Sao_Paulo 0 0 9 * * ?", "2018-02-17T09:00:00-0200"},
+		{"2018-02-18T00:00:00-0200", "TZ=America/Sao_Paulo 0 0 9 * * ?", "2018-02-17T09:00:00-0200"},
+		{"2018-11-04T01:00:00-0200", "TZ=America/Sao_Paulo 0 0 9 * * ?", "2018-11-03T09:00:00-0300"},
+		{"2018-11-04T00:00:00-0200", "TZ=America/Sao_Paulo 0 0 9 * * ?", "2018-11-03T09:00:00-0300"},
+		{"2018-11-04T00:00:00-0300", "TZ=America/Sao_Paulo 0 0 9 * * ?", "2018-11-03T09:00:00-0300"},
+	}
+
+	for _, c := range runs {
+		sched, err := secondParser.Parse(c.spec)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		actual := sched.Previous(getTime(c.time))
+		expected := getTime(c.expected)
+		if !actual.Equal(expected) {
+			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
+		}
+	}
+}
+
 func TestErrors(t *testing.T) {
 	invalidSpecs := []string{
 		"xyz",


### PR DESCRIPTION
Hello,
I added the Previous method to the Schedule interface, as well as the implementation of this method to SpecSchedule. This method works on the same principle as the Next () method but on the other hand allows you to deduce the previous date where the schedule would have been activated.

This method is useful to us in order to define a list of dynamic configurations scheduled by cron  and to deduce which configuration to use when applying these configurations.