### PR TITLE
Added support for setting UTC offset for schedule

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -100,6 +100,18 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 			return nil, fmt.Errorf("provided bad location %s: %v", spec[eq+1:i], err)
 		}
 		spec = strings.TrimSpace(spec[i:])
+	} else if strings.HasPrefix(spec, "OFFSET=") {
+		var err error
+		var offset int
+		i := strings.Index(spec, " ")
+		eq := strings.Index(spec, "=")
+		if offset, err = strconv.Atoi(spec[eq+1 : i]); err != nil {
+			return nil, fmt.Errorf("can't convert offset to integer %s: %v", spec[eq+1:i], err)
+		} else {
+			loc = time.FixedZone("Offset", offset)
+		}
+
+		spec = strings.TrimSpace(spec[i:])
 	}
 
 	// Handle named schedules (descriptors), if configured


### PR DESCRIPTION
Sometimes there is no access to ZONEINFO database, but we need to set offset.
In this situation, we can create a fake timezone without a database.

https://golang.org/pkg/time/#LoadLocation