### PR TITLE
Add Time Mocking

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/mixer/clock"
 )
 
 // JobWrapper decorates the given Job with some behavior.
@@ -62,10 +64,10 @@ func DelayIfStillRunning(logger Logger) JobWrapper {
 	return func(j Job) Job {
 		var mu sync.Mutex
 		return FuncJob(func() {
-			start := time.Now()
+			start := clock.C.Now()
 			mu.Lock()
 			defer mu.Unlock()
-			if dur := time.Since(start); dur > time.Minute {
+			if dur := clock.C.Since(start); dur > time.Minute {
 				logger.Info("delay", "duration", dur)
 			}
 			j.Run()

--- a/cron_test.go
+++ b/cron_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/mixer/clock"
 )
 
 // Many tests schedule a job for every second, and then wait at most a second
@@ -669,6 +671,65 @@ func TestStopAndWait(t *testing.T) {
 		}
 
 	})
+}
+
+func TestScheduleBehavior(t *testing.T) {
+
+	loc := time.FixedZone("America/Los_Angeles", -7*60*60)
+	start := time.Date(2020, 7, 13, 11, 50, 0, 0, loc)
+	clk := clock.NewMockClock(start)
+	cron := New(
+		WithClock(clk),
+		WithChain(),
+		WithLocation(loc),
+	)
+
+	ch := make(chan bool)
+	cron.AddFunc("50 11 31 * *", func() {
+		ch <- true
+	})
+	cron.Start()
+	defer cron.Stop()
+
+	expectations := []struct {
+		month      string
+		shouldFire bool
+	}{
+		{month: "Jul", shouldFire: true},
+		{month: "Aug", shouldFire: true},
+		{month: "Sep", shouldFire: false},
+		{month: "Oct", shouldFire: true},
+		{month: "Nov", shouldFire: false},
+		{month: "Dec", shouldFire: true},
+		{month: "Jan", shouldFire: true},
+		{month: "Feb", shouldFire: false},
+		{month: "Mar", shouldFire: true},
+		{month: "Apr", shouldFire: false},
+		{month: "May", shouldFire: true},
+		{month: "Jun", shouldFire: false},
+	}
+
+	t.Logf("Start date: %s", clk.Now().Format(time.RFC3339))
+	for _, exp := range expectations {
+
+		time.Sleep(time.Millisecond)
+		clk.AddTime(clk.Now().AddDate(0, 1, 0).Sub(clk.Now()))
+		t.Logf("New date: %s", clk.Now().Format(time.RFC3339))
+		time.Sleep(time.Millisecond)
+
+		select {
+		case <-ch:
+			if !exp.shouldFire {
+				t.Fatalf("job unexpectedly fired in %s", exp.month)
+			}
+			t.Logf("job fired in %s", exp.month)
+		case <-time.After(time.Second):
+			if exp.shouldFire {
+				t.Fatalf("job should have fired in %s", exp.month)
+			}
+		}
+	}
+
 }
 
 func TestMultiThreadedStartAndStop(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/robfig/cron/v3
 
 go 1.12
+
+require github.com/mixer/clock v0.0.0-20190507173039-c311c17adb1f

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mixer/clock v0.0.0-20190507173039-c311c17adb1f h1:GVMwQJIugRbOBgPK5RvPdvKPCxFex4bx+MUj2oG70XI=
+github.com/mixer/clock v0.0.0-20190507173039-c311c17adb1f/go.mod h1:U8TDygO2XZh1RtBCgX7oRbJ7gmSH4C6FROsBdQ6QyCc=

--- a/option.go
+++ b/option.go
@@ -2,6 +2,8 @@ package cron
 
 import (
 	"time"
+
+	"github.com/mixer/clock"
 )
 
 // Option represents a modification to the default behavior of a Cron.
@@ -41,5 +43,12 @@ func WithChain(wrappers ...JobWrapper) Option {
 func WithLogger(logger Logger) Option {
 	return func(c *Cron) {
 		c.logger = logger
+	}
+}
+
+// WithClock uses the provided clock to track time.
+func WithClock(clk clock.Clock) Option {
+	return func(c *Cron) {
+		c.clk = clk
 	}
 }


### PR DESCRIPTION
This PR adds a `WithClock()` option, which uses [mixer/clock](https://github.com/mixer/clock) to simulate the passage of time.  Tests can be written to, for example, [verify the behavior of a given schedule](https://github.com/tooolbox/cron/blob/0ef26ab6babdcb0da403d1d4da95fdb371ec6f66/cron_test.go#L676).

This comes in handy for me personally as I'd like to test the interaction of a cron with my own service, over a long period of time.