### PR TITLE
Adds the WithOptionalSeconds() Option

### DIFF
--- a/option.go
+++ b/option.go
@@ -22,6 +22,14 @@ func WithSeconds() Option {
 	))
 }
 
+// WithOptionalSeconds overrides the parser used for interpreting job schedules to
+// include an optional seconds field as the first one.
+func WithOptionalSeconds() Option {
+	return WithParser(NewParser(
+		SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor,
+	))
+}
+
 // WithParser overrides the parser used for interpreting job schedules.
 func WithParser(p ScheduleParser) Option {
 	return func(c *Cron) {


### PR DESCRIPTION
As described in the readme itself. 

It'd be nice to be able to use that convention in a terse way, instead of the long notation specified in the readme.