### PR TITLE
Fix panic due to invalid schedule string

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -95,6 +95,9 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
 		var err error
 		i := strings.Index(spec, " ")
+		if i == -1 {
+			return nil, fmt.Errorf("provided no location %s", spec)
+		}
 		eq := strings.Index(spec, "=")
 		if loc, err = time.LoadLocation(spec[eq+1 : i]); err != nil {
 			return nil, fmt.Errorf("provided bad location %s: %v", spec[eq+1:i], err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -179,6 +179,23 @@ func TestParseSchedule(t *testing.T) {
 			t.Errorf("%s => expected %b, got %b", c.expr, c.expected, actual)
 		}
 	}
+
+	badEntries := []struct {
+		parser Parser
+		expr   string
+	}{
+		{secondParser, "TZ="},
+		{standardParser, "TZ="},
+		{secondParser, "CRON_TZ="},
+		{standardParser, "CRON_TZ="},
+	}
+
+	for _, c := range badEntries {
+		_, err := c.parser.Parse(c.expr)
+		if err == nil {
+			t.Errorf("%s => expected error but got none", c.expr)
+		}
+	}
 }
 
 func TestOptionalSecondSchedule(t *testing.T) {


### PR DESCRIPTION
Fix a bug where cron panics if [the schedule string ("spec")](https://github.com/robfig/cron/blob/6a8421bcff44c2a9889075724070baaebf8dcd72/parser.go#L88) has a particular format, namely exactly "TZ=" or "CRON_TZ=". If this string is user controlled that user may be able to cause a panic and thereby exit the program that is using cron. Alternatively, if the string is constructed dynamically by the program and there is a mistake in that logic, the program would panic unexpectedly.

The solution I propose is simply to check against the condition that causes cron to panic. There are alternative solution, e.g.:
- Using  more complex logic (using e.g. regexp) to detect the "(CRON_)TZ" syntax.
- Updating parsing logic so that [the `"provided bad location"` error](https://github.com/robfig/cron/blob/6a8421bcff44c2a9889075724070baaebf8dcd72/parser.go#L100) is returned. I opted away from this as I figured it might be useful to distinguish these two scenarios.

I also added some tests for these strings to ensure they're properly accounted for in the future.

<sup>_Disclosure_: I found this bug using https://github.com/dvyukov/go-fuzz and did not encounter any other parsing issues.</sup>