### PR TITLE
Add support for running a one off job using an exact time

### DIFF
--- a/constantdelay.go
+++ b/constantdelay.go
@@ -25,3 +25,9 @@ func Every(duration time.Duration) ConstantDelaySchedule {
 func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
 	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
 }
+
+// isOneOff returns a true or false if this schedule should only be ran once.
+// For ConstantDelaySchedule this will ALWAYS return false
+func (schedule ConstantDelaySchedule) isOneOff() bool {
+	return false
+}

--- a/cron_test.go
+++ b/cron_test.go
@@ -541,6 +541,10 @@ func (*ZeroSchedule) Next(time.Time) time.Time {
 	return time.Time{}
 }
 
+func (*ZeroSchedule) isOneOff() bool {
+	return false
+}
+
 // Tests that job without time does not run
 func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	cron := newWithSeconds()

--- a/exactschedule.go
+++ b/exactschedule.go
@@ -1,0 +1,20 @@
+package cron
+
+import "time"
+
+// ExactSchedule represents a schedule that will only run at the exact time and date provided.
+type ExactSchedule struct {
+	Schedule time.Time
+}
+
+// Next returns the next time this should be run.
+// This rounds so that the next activation time will be on the second.
+func (schedule ExactSchedule) Next(t time.Time) time.Time {
+	return schedule.Schedule
+}
+
+// isOneOff returns a true or false if this schedule should only be ran once.
+// For ExactSchedule this will ALWAYS return true
+func (schedule ExactSchedule) isOneOff() bool {
+	return true
+}

--- a/exactschedule_test.go
+++ b/exactschedule_test.go
@@ -1,0 +1,37 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeBeforeNow(t *testing.T) {
+
+	cron := newWithSeconds()
+
+	_, err := cron.ScheduleAtExactTime(time.Now().AddDate(-1, 0, 0), func() {
+		t.Error("Cron scheduled a job with a time in the past")
+	})
+	if err == nil {
+		t.Error("Expected an error when scheduling a job with a time in the past")
+	}
+	if err.Error() != "scheduleTime must be in the future" {
+		t.Errorf("Unexpected an error when scheduling a job with a time in the past: %v", err)
+	}
+}
+
+func TestExactScheduleRunsOnce(t *testing.T) {
+	cron := newWithSeconds()
+	cron.AddFunc("* * * * * *", func() {})
+	cron.ScheduleAtExactTime(time.Now().Add(1*time.Second), func() {})
+
+	if len(cron.Entries()) != 2 {
+		t.Error("Expected cron entries to include 2 entries before starting cron")
+	}
+	cron.Start()
+	defer cron.Stop()
+	<-time.After(OneSecond)
+	if len(cron.Entries()) != 1 {
+		t.Error("Expected cron entries to include 1 entry after running cron")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/robfig/cron/v3
+module github.com/NeilGerring/cron/v3
 
 go 1.12

--- a/spec.go
+++ b/spec.go
@@ -53,6 +53,12 @@ const (
 	starBit = 1 << 63
 )
 
+// isOneOff returns a true or false if this schedule should only be ran once.
+// For ConstantDelaySchedule this will ALWAYS return false
+func (s *SpecSchedule) isOneOff() bool {
+	return false
+}
+
 // Next returns the next time this schedule is activated, greater than the given
 // time.  If no time can be found to satisfy the schedule, return the zero time.
 func (s *SpecSchedule) Next(t time.Time) time.Time {


### PR DESCRIPTION
This adds support for adding a job using an exact timestamp that will only be ran once