### PR TITLE
add '#' support for the day-of-week field

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -61,11 +61,11 @@ type Parser struct {
 //  sched, err := specParser.Parse("0 0 15 */3 *")
 //
 //  // Same as above, just excludes time fields
-//  subsParser := NewParser(Dom | Month | Dow)
+//  specParser := NewParser(Dom | Month | Dow)
 //  sched, err := specParser.Parse("15 */3 *")
 //
 //  // Same as above, just makes Dow optional
-//  subsParser := NewParser(Dom | Month | DowOptional)
+//  specParser := NewParser(Dom | Month | DowOptional)
 //  sched, err := specParser.Parse("15 */3")
 //
 func NewParser(options ParseOption) Parser {

--- a/parser_test.go
+++ b/parser_test.go
@@ -86,7 +86,7 @@ func TestAll(t *testing.T) {
 		{hours, 0xffffff},            // 0-23: 24 ones
 		{dom, 0xfffffffe},            // 1-31: 31 ones, 1 zero
 		{months, 0x1ffe},             // 1-12: 12 ones, 1 zero
-		{dow, 0x7f},                  // 0-6: 7 ones
+		{dow, 0x7ffffffff},           // 0-6: 7 ones
 	}
 
 	for _, c := range allBits {

--- a/spec.go
+++ b/spec.go
@@ -37,7 +37,7 @@ var (
 		"nov": 11,
 		"dec": 12,
 	}}
-	dow = bounds{0, 6, map[string]uint{
+	dow = bounds{0, 34, map[string]uint{
 		"sun": 0,
 		"mon": 1,
 		"tue": 2,
@@ -179,7 +179,7 @@ WRAP:
 func dayMatches(s *SpecSchedule, t time.Time) bool {
 	var (
 		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
-		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
+		dowMatch bool = 1<<(uint(t.Weekday())+7*(uint(t.Day()-1)/7))&s.Dow > 0
 	)
 	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
 		return domMatch && dowMatch


### PR DESCRIPTION
#159

extend the dow field length from 7 bits to a maximum of 35 bits, to minimize modification, only m#n format is supported
