### PR TITLE
Use time.Truncate instead of explicit modulo/subtraction.

### DIFF
--- a/constantdelay.go
+++ b/constantdelay.go
@@ -16,12 +16,12 @@ func Every(duration time.Duration) ConstantDelaySchedule {
 		duration = time.Second
 	}
 	return ConstantDelaySchedule{
-		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
+		Delay: duration.Truncate(time.Second),
 	}
 }
 
 // Next returns the next time this should be run.
 // This rounds so that the next activation time will be on the second.
 func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
-	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
+	return t.Add(schedule.Delay).Truncate(time.Second)
 }


### PR DESCRIPTION
`time.Duration.Truncate` and `time.Time.Truncate` were introduced in Go 1.9 and 1.1, and thus I guess they are okay.