### PR TITLE
cron/byTime: Optimization determine the nexe entry

### DIFF
--- a/cron_test.go
+++ b/cron_test.go
@@ -678,6 +678,30 @@ func TestMultiThreadedStartAndStop(t *testing.T) {
 	cron.Stop()
 }
 
+func TestMinimumTime(t *testing.T) {
+	now := time.Now()
+	times := []time.Time{
+		now.Add(time.Second * 3),
+		now.Add(time.Second * 2),
+		now.Add(time.Second * -1),
+		now.Add(time.Minute * 1),
+		now.Add(time.Minute * -3),
+		now.Add(time.Minute * -2),
+		now.Add(time.Second * -180),
+		now.Add(time.Second * 2),
+	}
+	expected := 4
+
+	entries := []*Entry{}
+	for _, t := range times {
+		entries = append(entries, &Entry{Next: t})
+	}
+
+	if byTime(entries).Min() != expected {
+		t.Error("Get the minimum entry index by time is unexpected")
+	}
+}
+
 func wait(wg *sync.WaitGroup) chan bool {
 	ch := make(chan bool)
 	go func() {


### PR DESCRIPTION
## Optimization determine the nexe entry, 
from sort.Sort() to byTime.Min(), 
> sort.Sort:         `one call to data.Len and O(n*log(n)) calls to data.Less and data.Swap`, 
> byTime.Min:    `O(n) calls to data.Less and data.Swap`.
