### PR TITLE
Link to v3 docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](http://godoc.org/github.com/robfig/cron?status.png)](http://godoc.org/github.com/robfig/cron)
+[![GoDoc](http://godoc.org/github.com/robfig/cron?status.png)](https://pkg.go.dev/github.com/robfig/cron/v3)
 [![Build Status](https://travis-ci.org/robfig/cron.svg?branch=master)](https://travis-ci.org/robfig/cron)
 
 # cron
@@ -16,7 +16,7 @@ import "github.com/robfig/cron/v3"
 It requires Go 1.11 or later due to usage of Go Modules.
 
 Refer to the documentation here:
-http://godoc.org/github.com/robfig/cron
+https://pkg.go.dev/github.com/robfig/cron/v3
 
 The rest of this document describes the the advances in v3 and a list of
 breaking changes for users that wish to upgrade from an earlier version.


### PR DESCRIPTION
The README currently advertises and shows how to import v3 yet still links to the v2 documentation.