### PR TITLE
Add support for using mock clock in cron

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -26,9 +26,12 @@ func NewChain(c ...JobWrapper) Chain {
 // Then decorates the given job with all JobWrappers in the chain.
 //
 // This:
-//     NewChain(m1, m2, m3).Then(job)
+//
+//	NewChain(m1, m2, m3).Then(job)
+//
 // is equivalent to:
-//     m1(m2(m3(job)))
+//
+//	m1(m2(m3(job)))
 func (c Chain) Then(j Job) Job {
 	for i := range c.wrappers {
 		j = c.wrappers[len(c.wrappers)-i-1](j)
@@ -85,7 +88,7 @@ func DelayIfStillRunningWithClock(logger Logger, clk clock.Clock) JobWrapper {
 // still running. It logs skips to the given logger at Info level.
 func SkipIfStillRunning(logger Logger) JobWrapper {
 	return func(j Job) Job {
-		var ch = make(chan struct{}, 1)
+		ch := make(chan struct{}, 1)
 		ch <- struct{}{}
 		return FuncJob(func() {
 			select {

--- a/chain_test.go
+++ b/chain_test.go
@@ -104,7 +104,7 @@ func TestChainDelayIfStillRunning(t *testing.T) {
 		var j countJob
 		wrappedJob := NewChain(DelayIfStillRunning(DiscardLogger)).Then(&j)
 		go wrappedJob.Run()
-		time.Sleep(2 * time.Millisecond) // Give the job 2ms to complete.
+		time.Sleep(50 * time.Millisecond) // Give the job 50 ms to complete.
 		if c := j.Done(); c != 1 {
 			t.Errorf("expected job run once, immediately, got %d", c)
 		}
@@ -115,10 +115,10 @@ func TestChainDelayIfStillRunning(t *testing.T) {
 		wrappedJob := NewChain(DelayIfStillRunning(DiscardLogger)).Then(&j)
 		go func() {
 			go wrappedJob.Run()
-			time.Sleep(time.Millisecond)
+			time.Sleep(10* time.Millisecond)
 			go wrappedJob.Run()
 		}()
-		time.Sleep(3 * time.Millisecond) // Give both jobs 3ms to complete.
+		time.Sleep(100 * time.Millisecond) // Give both jobs 100 ms to complete.
 		if c := j.Done(); c != 2 {
 			t.Errorf("expected job run twice, immediately, got %d", c)
 		}
@@ -126,24 +126,24 @@ func TestChainDelayIfStillRunning(t *testing.T) {
 
 	t.Run("second run delayed if first not done", func(t *testing.T) {
 		var j countJob
-		j.delay = 10 * time.Millisecond
+		j.delay = 100 * time.Millisecond
 		wrappedJob := NewChain(DelayIfStillRunning(DiscardLogger)).Then(&j)
 		go func() {
 			go wrappedJob.Run()
-			time.Sleep(time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 			go wrappedJob.Run()
 		}()
 
-		// After 5ms, the first job is still in progress, and the second job was
+		// After 50 ms, the first job is still in progress, and the second job was
 		// run but should be waiting for it to finish.
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		started, done := j.Started(), j.Done()
 		if started != 1 || done != 0 {
 			t.Error("expected first job started, but not finished, got", started, done)
 		}
 
 		// Verify that the second job completes.
-		time.Sleep(25 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		started, done = j.Started(), j.Done()
 		if started != 2 || done != 2 {
 			t.Error("expected both jobs done, got", started, done)
@@ -158,7 +158,7 @@ func TestChainSkipIfStillRunning(t *testing.T) {
 		var j countJob
 		wrappedJob := NewChain(SkipIfStillRunning(DiscardLogger)).Then(&j)
 		go wrappedJob.Run()
-		time.Sleep(2 * time.Millisecond) // Give the job 2ms to complete.
+		time.Sleep(50 * time.Millisecond) // Give the job 50ms to complete.
 		if c := j.Done(); c != 1 {
 			t.Errorf("expected job run once, immediately, got %d", c)
 		}
@@ -169,10 +169,10 @@ func TestChainSkipIfStillRunning(t *testing.T) {
 		wrappedJob := NewChain(SkipIfStillRunning(DiscardLogger)).Then(&j)
 		go func() {
 			go wrappedJob.Run()
-			time.Sleep(time.Millisecond)
+			time.Sleep(10* time.Millisecond)
 			go wrappedJob.Run()
 		}()
-		time.Sleep(3 * time.Millisecond) // Give both jobs 3ms to complete.
+		time.Sleep(100 * time.Millisecond) // Give both jobs 100ms to complete.
 		if c := j.Done(); c != 2 {
 			t.Errorf("expected job run twice, immediately, got %d", c)
 		}
@@ -180,24 +180,24 @@ func TestChainSkipIfStillRunning(t *testing.T) {
 
 	t.Run("second run skipped if first not done", func(t *testing.T) {
 		var j countJob
-		j.delay = 10 * time.Millisecond
+		j.delay = 100 * time.Millisecond
 		wrappedJob := NewChain(SkipIfStillRunning(DiscardLogger)).Then(&j)
 		go func() {
 			go wrappedJob.Run()
-			time.Sleep(time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 			go wrappedJob.Run()
 		}()
 
-		// After 5ms, the first job is still in progress, and the second job was
+		// After 50ms, the first job is still in progress, and the second job was
 		// aleady skipped.
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		started, done := j.Started(), j.Done()
 		if started != 1 || done != 0 {
 			t.Error("expected first job started, but not finished, got", started, done)
 		}
 
 		// Verify that the first job completes and second does not run.
-		time.Sleep(25 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		started, done = j.Started(), j.Done()
 		if started != 1 || done != 1 {
 			t.Error("expected second job skipped, got", started, done)

--- a/cron.go
+++ b/cron.go
@@ -100,17 +100,17 @@ func (s byTime) Less(i, j int) bool {
 //
 // Available Settings
 //
-//   Time Zone
-//     Description: The time zone in which schedules are interpreted
-//     Default:     time.Local
+//	Time Zone
+//	  Description: The time zone in which schedules are interpreted
+//	  Default:     time.Local
 //
-//   Parser
-//     Description: Parser converts cron spec strings into cron.Schedules.
-//     Default:     Accepts this spec: https://en.wikipedia.org/wiki/Cron
+//	Parser
+//	  Description: Parser converts cron spec strings into cron.Schedules.
+//	  Default:     Accepts this spec: https://en.wikipedia.org/wiki/Cron
 //
-//   Chain
-//     Description: Wrap submitted jobs to customize behavior.
-//     Default:     A chain that recovers panics and logs them to stderr.
+//	Chain
+//	  Description: Wrap submitted jobs to customize behavior.
+//	  Default:     A chain that recovers panics and logs them to stderr.
 //
 // See "cron.With*" to modify the default behavior.
 func New(opts ...Option) *Cron {
@@ -341,7 +341,7 @@ func (c *Cron) Stop() context.Context {
 
 // entrySnapshot returns a copy of the current cron entry list.
 func (c *Cron) entrySnapshot() []Entry {
-	var entries = make([]Entry, len(c.entries))
+	entries := make([]Entry, len(c.entries))
 	for i, e := range c.entries {
 		entries[i] = *e
 	}

--- a/cron_test.go
+++ b/cron_test.go
@@ -390,7 +390,7 @@ func TestBlockingRun(t *testing.T) {
 	cron := newWithSeconds()
 	cron.AddFunc("* * * * * ?", func() { wg.Done() })
 
-	var unblockChan = make(chan struct{})
+	unblockChan := make(chan struct{})
 
 	go func() {
 		cron.Run()
@@ -409,7 +409,7 @@ func TestBlockingRun(t *testing.T) {
 
 // Test that double-running is a no-op
 func TestStartNoop(t *testing.T) {
-	var tickChan = make(chan struct{}, 2)
+	tickChan := make(chan struct{}, 2)
 
 	cron := newWithSeconds()
 	cron.AddFunc("* * * * * ?", func() {
@@ -669,7 +669,6 @@ func TestStopAndWait(t *testing.T) {
 		case <-time.After(time.Millisecond):
 			t.Error("context not done even when cron Stop is completed")
 		}
-
 	})
 }
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/benbjohnson/clock"
 )
 
 // Many tests schedule a job for every second, and then wait at most a second
@@ -669,6 +671,25 @@ func TestStopAndWait(t *testing.T) {
 		}
 
 	})
+}
+
+func TestMockClock(t *testing.T) {
+	clk := clock.NewMock()
+	clk.Set(time.Now())
+	cron := New(WithClock(clk))
+	counter := 0
+	cron.AddFunc("@every 1s", func() {
+		counter += 1
+	})
+	cron.Start()
+	defer cron.Stop()
+	for i := 0; i <= 10; i++ {
+		clk.Add(1 * time.Second)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if counter != 10 {
+		t.Errorf("expected 10 calls, got %d", counter)
+	}
 }
 
 func TestMultiThreadedStartAndStop(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ Import it in your program as:
 
 It requires Go 1.11 or later due to usage of Go Modules.
 
-Usage
+# Usage
 
 Callers may register Funcs to be invoked on a given schedule.  Cron will run
 them in their own goroutines.
@@ -54,7 +54,7 @@ Month and Day-of-week field values are case insensitive.  "SUN", "Sun", and
 The specific interpretation of the format is based on the Cron Wikipedia page:
 https://en.wikipedia.org/wiki/Cron
 
-Alternative Formats
+# Alternative Formats
 
 Alternative Cron expression formats support other fields like seconds. You can
 implement that by creating a custom Parser as follows.
@@ -73,7 +73,7 @@ parser you saw earlier, except that its seconds field is REQUIRED:
 That emulates Quartz, the most popular alternative Cron schedule format:
 http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html
 
-Special Characters
+# Special Characters
 
 Asterisk ( * )
 
@@ -105,7 +105,7 @@ Question mark ( ? )
 Question mark may be used instead of '*' for leaving either day-of-month or
 day-of-week blank.
 
-Predefined schedules
+# Predefined schedules
 
 You may use one of several pre-defined schedules in place of a cron expression.
 
@@ -117,12 +117,12 @@ You may use one of several pre-defined schedules in place of a cron expression.
 	@daily (or @midnight)  | Run once a day, midnight                   | 0 0 * * *
 	@hourly                | Run once an hour, beginning of hour        | 0 * * * *
 
-Intervals
+# Intervals
 
 You may also schedule a job to execute at fixed intervals, starting at the time it's added
 or cron is run. This is supported by formatting the cron spec like this:
 
-    @every <duration>
+	@every <duration>
 
 where "duration" is a string accepted by time.ParseDuration
 (http://golang.org/pkg/time/#ParseDuration).
@@ -134,13 +134,13 @@ Note: The interval does not take the job runtime into account.  For example,
 if a job takes 3 minutes to run, and it is scheduled to run every 5 minutes,
 it will have only 2 minutes of idle time between each run.
 
-Time zones
+# Time zones
 
 By default, all interpretation and scheduling is done in the machine's local
 time zone (time.Local). You can specify a different time zone on construction:
 
-      cron.New(
-          cron.WithLocation(time.UTC))
+	cron.New(
+	    cron.WithLocation(time.UTC))
 
 Individual cron schedules may also override the time zone they are to be
 interpreted in by providing an additional space-separated field at the beginning
@@ -169,7 +169,7 @@ The prefix "TZ=(TIME ZONE)" is also supported for legacy compatibility.
 Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
 not be run!
 
-Job Wrappers
+# Job Wrappers
 
 A Cron runner may be configured with a chain of job wrappers to add
 cross-cutting functionality to all submitted jobs. For example, they may be used
@@ -192,7 +192,7 @@ Install wrappers for individual jobs by explicitly wrapping them:
 		cron.SkipIfStillRunning(logger),
 	).Then(job)
 
-Thread safety
+# Thread safety
 
 Since the Cron service runs concurrently with the calling code, some amount of
 care must be taken to ensure proper synchronization.
@@ -200,7 +200,7 @@ care must be taken to ensure proper synchronization.
 All cron methods are designed to be correctly synchronized as long as the caller
 ensures that invocations have a clear happens-before ordering between them.
 
-Logging
+# Logging
 
 Cron defines a Logger interface that is a subset of the one defined in
 github.com/go-logr/logr. It has two logging levels (Info and Error), and
@@ -216,16 +216,15 @@ Activate it with a one-off logger as follows:
 		cron.WithLogger(
 			cron.VerbosePrintfLogger(log.New(os.Stdout, "cron: ", log.LstdFlags))))
 
-
-Implementation
+# Implementation
 
 Cron entries are stored in an array, sorted by their next activation time.  Cron
 sleeps until the next job is due to be run.
 
 Upon waking:
- - it runs each entry that is active on that second
- - it calculates the next run times for the jobs that were run
- - it re-sorts the array of entries by next activation time.
- - it goes to sleep until the soonest job.
+  - it runs each entry that is active on that second
+  - it calculates the next run times for the jobs that were run
+  - it re-sorts the array of entries by next activation time.
+  - it goes to sleep until the soonest job.
 */
 package cron

--- a/doc.go
+++ b/doc.go
@@ -36,7 +36,23 @@ them in their own goroutines.
 	..
 	c.Stop()  // Stop the scheduler (does not stop any jobs already running).
 
-CRON Expression Format
+# Time mocking
+
+import "github.com/benbjohnson/clock"
+
+clk := clock.NewMock()
+
+c := cron.New(cron.WithClock(clk))
+
+	c.AddFunc("@every 1h", func() {
+		fmt.Println("Every hour")
+	})
+
+c.Start()
+
+clk.Add(1 * time.Hour)
+
+# CRON Expression Format
 
 A cron expression represents a set of times, using 5 space-separated fields.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/robfig/cron/v3
 
 go 1.12
+
+require (
+	github.com/benbjohnson/clock v1.3.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/robfig/cron/v3
 
 go 1.12
 
-require (
-	github.com/benbjohnson/clock v1.3.0 // indirect
-)
+require github.com/benbjohnson/clock v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/mixer/clock v0.0.0-20190507173039-c311c17adb1f h1:GVMwQJIugRbOBgPK5RvPdvKPCxFex4bx+MUj2oG70XI=
+github.com/mixer/clock v0.0.0-20190507173039-c311c17adb1f/go.mod h1:U8TDygO2XZh1RtBCgX7oRbJ7gmSH4C6FROsBdQ6QyCc=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/mixer/clock v0.0.0-20190507173039-c311c17adb1f h1:GVMwQJIugRbOBgPK5RvPdvKPCxFex4bx+MUj2oG70XI=
-github.com/mixer/clock v0.0.0-20190507173039-c311c17adb1f/go.mod h1:U8TDygO2XZh1RtBCgX7oRbJ7gmSH4C6FROsBdQ6QyCc=

--- a/option.go
+++ b/option.go
@@ -2,6 +2,8 @@ package cron
 
 import (
 	"time"
+
+	"github.com/benbjohnson/clock"
 )
 
 // Option represents a modification to the default behavior of a Cron.
@@ -41,5 +43,12 @@ func WithChain(wrappers ...JobWrapper) Option {
 func WithLogger(logger Logger) Option {
 	return func(c *Cron) {
 		c.logger = logger
+	}
+}
+
+// WithClock uses the provided clock to track time.
+func WithClock(clk clock.Clock) Option {
+	return func(c *Cron) {
+		c.clk = clk
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -15,7 +15,7 @@ func TestWithLocation(t *testing.T) {
 }
 
 func TestWithParser(t *testing.T) {
-	var parser = NewParser(Dow)
+	parser := NewParser(Dow)
 	c := New(WithParser(parser))
 	if c.parser != parser {
 		t.Error("expected provided parser")
@@ -24,7 +24,7 @@ func TestWithParser(t *testing.T) {
 
 func TestWithVerboseLogger(t *testing.T) {
 	var buf syncWriter
-	var logger = log.New(&buf, "", log.LstdFlags)
+	logger := log.New(&buf, "", log.LstdFlags)
 	c := New(WithLogger(VerbosePrintfLogger(logger)))
 	if c.logger.(printfLogger).logger != logger {
 		t.Error("expected provided logger")

--- a/parser.go
+++ b/parser.go
@@ -56,18 +56,17 @@ type Parser struct {
 //
 // Examples
 //
-//  // Standard parser without descriptors
-//  specParser := NewParser(Minute | Hour | Dom | Month | Dow)
-//  sched, err := specParser.Parse("0 0 15 */3 *")
+//	// Standard parser without descriptors
+//	specParser := NewParser(Minute | Hour | Dom | Month | Dow)
+//	sched, err := specParser.Parse("0 0 15 */3 *")
 //
-//  // Same as above, just excludes time fields
-//  specParser := NewParser(Dom | Month | Dow)
-//  sched, err := specParser.Parse("15 */3 *")
+//	// Same as above, just excludes time fields
+//	specParser := NewParser(Dom | Month | Dow)
+//	sched, err := specParser.Parse("15 */3 *")
 //
-//  // Same as above, just makes Dow optional
-//  specParser := NewParser(Dom | Month | DowOptional)
-//  sched, err := specParser.Parse("15 */3")
-//
+//	// Same as above, just makes Dow optional
+//	specParser := NewParser(Dom | Month | DowOptional)
+//	sched, err := specParser.Parse("15 */3")
 func NewParser(options ParseOption) Parser {
 	optionals := 0
 	if options&DowOptional > 0 {
@@ -91,7 +90,7 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 	}
 
 	// Extract timezone if present
-	var loc = time.Local
+	loc := time.Local
 	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
 		var err error
 		i := strings.Index(spec, " ")
@@ -247,7 +246,9 @@ func getField(field string, r bounds) (uint64, error) {
 }
 
 // getRange returns the bits indicated by the given expression:
-//   number | number "-" number [ "/" number ]
+//
+//	number | number "-" number [ "/" number ]
+//
 // or error parsing range.
 func getRange(expr string, r bounds) (uint64, error) {
 	var (
@@ -418,7 +419,6 @@ func parseDescriptor(descriptor string, loc *time.Location) (Schedule, error) {
 			Dow:      all(dow),
 			Location: loc,
 		}, nil
-
 	}
 
 	const every = "@every "

--- a/parser_test.go
+++ b/parser_test.go
@@ -119,7 +119,7 @@ func TestBits(t *testing.T) {
 }
 
 func TestParseScheduleErrors(t *testing.T) {
-	var tests = []struct{ expr, err string }{
+	tests := []struct{ expr, err string }{
 		{"* 5 j * * *", "failed to parse int from"},
 		{"@every Xm", "failed to parse duration"},
 		{"@unrecognized", "unrecognized descriptor"},

--- a/spec_test.go
+++ b/spec_test.go
@@ -219,7 +219,7 @@ func getTime(value string) time.Time {
 		return time.Time{}
 	}
 
-	var location = time.Local
+	location := time.Local
 	if strings.HasPrefix(value, "TZ=") {
 		parts := strings.Fields(value)
 		loc, err := time.LoadLocation(parts[0][len("TZ="):])
@@ -230,7 +230,7 @@ func getTime(value string) time.Time {
 		value = parts[1]
 	}
 
-	var layouts = []string{
+	layouts := []string{
 		"Mon Jan 2 15:04 2006",
 		"Mon Jan 2 15:04:05 2006",
 	}


### PR DESCRIPTION
This PR uses https://github.com/benbjohnson/clock to mock the time. 
Adding support for using mock clock with cron will be helpful to write test cases and verify cron behaviour. 

Similar to this PR https://github.com/robfig/cron/pull/327 but uses a more up to date mock clock 

PR also contains fix for flaky unit tests on windows and minor linting fixes
