### PR TITLE
reset next job execution if the system time has been moved backwards

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -97,17 +97,17 @@ func (s byTime) Less(i, j int) bool {
 //
 // Available Settings
 //
-//   Time Zone
-//     Description: The time zone in which schedules are interpreted
-//     Default:     time.Local
+//	Time Zone
+//	  Description: The time zone in which schedules are interpreted
+//	  Default:     time.Local
 //
-//   Parser
-//     Description: Parser converts cron spec strings into cron.Schedules.
-//     Default:     Accepts this spec: https://en.wikipedia.org/wiki/Cron
+//	Parser
+//	  Description: Parser converts cron spec strings into cron.Schedules.
+//	  Default:     Accepts this spec: https://en.wikipedia.org/wiki/Cron
 //
-//   Chain
-//     Description: Wrap submitted jobs to customize behavior.
-//     Default:     A chain that recovers panics and logs them to stderr.
+//	Chain
+//	  Description: Wrap submitted jobs to customize behavior.
+//	  Default:     A chain that recovers panics and logs them to stderr.
 //
 // See "cron.With*" to modify the default behavior.
 func New(opts ...Option) *Cron {
@@ -256,7 +256,17 @@ func (c *Cron) run() {
 			// and stop requests.
 			timer = time.NewTimer(100000 * time.Hour)
 		} else {
-			timer = time.NewTimer(c.entries[0].Next.Sub(now))
+			entry := c.entries[0]
+			if !entry.Prev.IsZero() && entry.Prev.After(now) {
+				// time has moved back, we have to reset the next activation times for each entry.
+				for _, e := range c.entries {
+					c.logger.Info("reset schedule", "now", now, "entry", e.ID, "prev", e.Prev, "next", e.Next)
+					e.Prev = time.Time{}
+					e.Next = e.Schedule.Next(now)
+					c.logger.Info("new schedule", "now", now, "entry", e.ID, "next", e.Next)
+				}
+			}
+			timer = time.NewTimer(entry.Next.Sub(now))
 		}
 
 		for {


### PR DESCRIPTION
Suppose you have a job scheduled every minute.

The current time is 15:00:00 and for reasons outside our control it is set to 17:00:00, the job runs as expected and "Next" will be set to 17:01:00. 
If the system clock returns to the correct time and so now is, for example, 15:01:00, when we calculate the duration of the timer here

https://github.com/robfig/cron/blob/bc59245fe10efaed9d51b56900192527ed733435/cron.go#L259

we will have something like 2 hours and then no job runs for 2 hours.

This patch fixes the issue. Thank you