### PR TITLE
Supporting customize Timer to controll the scheduling behavior

### DIFF
--- a/option.go
+++ b/option.go
@@ -43,3 +43,11 @@ func WithLogger(logger Logger) Option {
 		c.logger = logger
 	}
 }
+
+// WithTimerFunc specifies a Timer creator. If not specified, NewStandardTimer will be used by default. Refer to the Timer documentation for details.
+// This option generally used for testing
+func WithTimerFunc(timer func(time.Duration) Timer) Option {
+	return func(c *Cron) {
+		c.timerFn = timer
+	}
+}

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,30 @@
+package cron
+
+import "time"
+
+// The Timer works just like time.Timer, and cron schedules Jobs by waiting for the time event emitted by Timer.
+// By default, the standard Timer returned by NewStandardTimer is used.
+// You can also customize a Timer with WithTimerFunc option to control scheduling behavior.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+}
+
+// NewStandardTimer returns a Timer created using the standard time.Timer.
+func NewStandardTimer(d time.Duration) Timer {
+	return &standardTimer{
+		timer: time.NewTimer(d),
+	}
+}
+
+type standardTimer struct {
+	timer *time.Timer
+}
+
+func (t *standardTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t *standardTimer) Stop() bool {
+	return t.timer.Stop()
+}


### PR DESCRIPTION
Add a new interface `Timer` replace  `time.Timer` for scheduling the job.

So that the user can create custom timer instead of using standard `time.Timer`，mainly used for testing。

eg.

```go
import (
	"github.com/benbjohnson/clock"
        "github.com/robfig/cron/v3"
)

func main() {
    mockClock := clock.NewMock()
    cronEngine = cron.New(cron.WithTimerFunc(NewMockTimerFunc(mockClock)))
}

func NewMockTimerFunc(mock *clock.Mock) func(time.Duration) cron.Timer {
	return func(d time.Duration) cron.Timer {
		return &mockTimer{
			timer: mock.Timer(d),
		}
	}
}

type mockTimer struct {
	timer *clock.Timer
}

func (t *mockTimer) C() <-chan time.Time {
	return t.timer.C
}

func (t *mockTimer) Stop() bool {
	return t.timer.Stop()
}
```