### PR TITLE
Add external logger support

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -52,6 +53,33 @@ func (pl printfLogger) Info(msg string, keysAndValues ...interface{}) {
 func (pl printfLogger) Error(err error, msg string, keysAndValues ...interface{}) {
 	keysAndValues = formatTimes(keysAndValues)
 	pl.logger.Printf(
+		formatString(len(keysAndValues)+2),
+		append([]interface{}{msg, "error", err}, keysAndValues...)...)
+}
+
+type externalLogger struct {
+	logger *log.Logger
+}
+
+// NewExternalLogger allows for providing an external logging interface through an io.Writer
+func NewExternalLogger(w io.Writer) *externalLogger {
+	l := log.New(w, "cron: ", log.Llongfile)
+
+	el := externalLogger{
+		logger: l,
+	}
+
+	return &el
+}
+
+func (el *externalLogger) Info(msg string, keysAndValues ...interface{}) {
+	el.logger.Printf(
+		formatString(len(keysAndValues)),
+		append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func (el *externalLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	el.logger.Printf(
 		formatString(len(keysAndValues)+2),
 		append([]interface{}{msg, "error", err}, keysAndValues...)...)
 }


### PR DESCRIPTION
Hello,

This PR adds support for external loggers via `io.Writer`. Sample code of it working is below:

```go
package main

import (
	"fmt"
	"log"
	"time"

	"github.com/robfig/cron/v3"
	"go.uber.org/zap"
)

func main() {
	zapLogger, _ := zap.NewDevelopment()

	stdOutLogger := zap.NewStdLog(zapLogger)

	zW := stdOutLogger.Writer()

	el := cron.NewExternalLogger(zW)
	c := cron.New(
		cron.WithChain(cron.SkipIfStillRunning(el)),
		cron.WithSeconds(),
	)

	if _, err := c.AddFunc("* * * * * *", testJob); err != nil {
		log.Fatal(err)
	}

	c.Start()

	time.Sleep(1 * time.Minute)
}

func testJob() {
	time.Sleep(3 * time.Second)

	fmt.Println("job")
}
```

Should output something like:

```
2023-10-26T14:46:27.000-0500	INFO	cron/logger.go:76	cron: /home/.../cron/logger.go:76: skip
2023-10-26T14:46:28.000-0500	INFO	cron/logger.go:76	cron: /home/.../cron/logger.go:76: skip
2023-10-26T14:46:29.000-0500	INFO	cron/logger.go:76	cron: /home/.../cron/logger.go:76: skip
job
2023-10-26T14:46:31.000-0500	INFO	cron/logger.go:76	cron: /home/.../cron/logger.go:76: skip
2023-10-26T14:46:32.000-0500	INFO	cron/logger.go:76	cron: /home/.../cron/logger.go:76: skip
job
2023-10-26T14:46:33.000-0500	INFO	cron/logger.go:76	cron: /home/.../cron/logger.go:76: skip
```