### PR TITLE
feat: add `ScheduleEntryNow` function to trigger entry immediately outside of schedule

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -11,19 +11,20 @@ import (
 // specified by the schedule. It may be started, stopped, and the entries may
 // be inspected while running.
 type Cron struct {
-	entries   []*Entry
-	chain     Chain
-	stop      chan struct{}
-	add       chan *Entry
-	remove    chan EntryID
-	snapshot  chan chan []Entry
-	running   bool
-	logger    Logger
-	runningMu sync.Mutex
-	location  *time.Location
-	parser    ScheduleParser
-	nextID    EntryID
-	jobWaiter sync.WaitGroup
+	entries     []*Entry
+	chain       Chain
+	stop        chan struct{}
+	add         chan *Entry
+	remove      chan EntryID
+	snapshot    chan chan []Entry
+	scheduleNow chan EntryID
+	running     bool
+	logger      Logger
+	runningMu   sync.Mutex
+	location    *time.Location
+	parser      ScheduleParser
+	nextID      EntryID
+	jobWaiter   sync.WaitGroup
 }
 
 // ScheduleParser is an interface for schedule spec parsers that return a Schedule
@@ -97,32 +98,33 @@ func (s byTime) Less(i, j int) bool {
 //
 // Available Settings
 //
-//   Time Zone
-//     Description: The time zone in which schedules are interpreted
-//     Default:     time.Local
+//	Time Zone
+//	  Description: The time zone in which schedules are interpreted
+//	  Default:     time.Local
 //
-//   Parser
-//     Description: Parser converts cron spec strings into cron.Schedules.
-//     Default:     Accepts this spec: https://en.wikipedia.org/wiki/Cron
+//	Parser
+//	  Description: Parser converts cron spec strings into cron.Schedules.
+//	  Default:     Accepts this spec: https://en.wikipedia.org/wiki/Cron
 //
-//   Chain
-//     Description: Wrap submitted jobs to customize behavior.
-//     Default:     A chain that recovers panics and logs them to stderr.
+//	Chain
+//	  Description: Wrap submitted jobs to customize behavior.
+//	  Default:     A chain that recovers panics and logs them to stderr.
 //
 // See "cron.With*" to modify the default behavior.
 func New(opts ...Option) *Cron {
 	c := &Cron{
-		entries:   nil,
-		chain:     NewChain(),
-		add:       make(chan *Entry),
-		stop:      make(chan struct{}),
-		snapshot:  make(chan chan []Entry),
-		remove:    make(chan EntryID),
-		running:   false,
-		runningMu: sync.Mutex{},
-		logger:    DefaultLogger,
-		location:  time.Local,
-		parser:    standardParser,
+		entries:     nil,
+		chain:       NewChain(),
+		add:         make(chan *Entry),
+		stop:        make(chan struct{}),
+		snapshot:    make(chan chan []Entry),
+		remove:      make(chan EntryID),
+		scheduleNow: make(chan EntryID),
+		running:     false,
+		runningMu:   sync.Mutex{},
+		logger:      DefaultLogger,
+		location:    time.Local,
+		parser:      standardParser,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -283,6 +285,17 @@ func (c *Cron) run() {
 				c.entries = append(c.entries, newEntry)
 				c.logger.Info("added", "now", now, "entry", newEntry.ID, "next", newEntry.Next)
 
+			case id := <-c.scheduleNow:
+				timer.Stop()
+				now = c.now().Add(100 * time.Millisecond)
+				for _, e := range c.entries {
+					if e.ID == id {
+						e.Next = now
+						c.logger.Info("scheduleNow", "now", now, "entry", e.ID, "next", e.Next)
+						break
+					}
+				}
+
 			case replyChan := <-c.snapshot:
 				replyChan <- c.entrySnapshot()
 				continue
@@ -352,4 +365,9 @@ func (c *Cron) removeEntry(id EntryID) {
 		}
 	}
 	c.entries = entries
+}
+
+// ScheduleEntryNow schedules an entry to run 100ms from now.
+func (c *Cron) ScheduleEntryNow(id EntryID) {
+	c.scheduleNow <- id
 }


### PR DESCRIPTION
This PR adds the `ScheduleEntryNow` function to the `Cron` struct to immediately schedule an entry to be run. The intention behind this addition is to enable entries to be run ad-hoc outside of their regular schedule. 