### PR TITLE
Add Jitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+.vscode

--- a/constantdelay_test.go
+++ b/constantdelay_test.go
@@ -26,7 +26,7 @@ func TestConstantDelayNext(t *testing.T) {
 		{"Mon Jul 9 23:35:51 2012", 25*time.Hour + 44*time.Minute + 24*time.Second, "Thu Jul 11 01:20:15 2012"},
 
 		// Wrap around months
-		{"Mon Jul 9 23:35 2012", 91*24*time.Hour + 25*time.Minute, "Thu Oct 9 00:00 2012"},
+		{"Mon Jun 9 23:35 2012", 91*24*time.Hour + 25*time.Minute, "Thu Sep 9 00:00 2012"}, // Don't do JUL->OCT otherwise daylight savings breaks the test in some time zones...
 
 		// Wrap around minute, hour, day, month, and year
 		{"Mon Dec 31 23:59:45 2012", 15 * time.Second, "Tue Jan 1 00:00:00 2013"},

--- a/cron.go
+++ b/cron.go
@@ -283,7 +283,7 @@ func (c *Cron) Run() {
 	c.run()
 }
 
-func (c *Cron) RecalculateTimer() {
+func (c *Cron) RecalculateNextEvent() {
 	c.recalculateTimer <- struct{}{}
 }
 

--- a/cron.go
+++ b/cron.go
@@ -352,6 +352,7 @@ func (c *Cron) run() {
 				c.removeEntry(id)
 				c.logger.Info("removed", "entry", id)
 			case <-c.recalculateTimer:
+				now = c.now()
 				break
 			}
 

--- a/cron.go
+++ b/cron.go
@@ -86,7 +86,7 @@ func calculateJitteredTime(now time.Time, jitterMaximum time.Duration) time.Time
 	if jitterMaximum > 0 {
 		val := jitterMaximum.Nanoseconds()
 		if val < math.MinInt64 {
-			val = jitterMaximum.Nanoseconds()+1
+			val = jitterMaximum.Nanoseconds() + 1
 		}
 		result = result.Add(time.Duration(rand.Int63n(val)))
 	}
@@ -308,8 +308,9 @@ func (c *Cron) run() {
 
 		for {
 			select {
-			case now = <-timer.C:
-				now = now.In(c.location)
+			case <-timer.C:
+				// Note: we can't just use the value which comes back from timer.C, because that won't respect the timeCallback, if one is set.
+				now = c.now()
 				c.logger.Info("wake", "now", now)
 
 				// Run every entry whose next time was less than now

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/team-rocos/cron/v3
+module github.com/robfig/cron/v3
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/robfig/cron/v3
+module github.com/team-rocos/cron/v3
 
 go 1.12

--- a/option.go
+++ b/option.go
@@ -43,3 +43,10 @@ func WithLogger(logger Logger) Option {
 		c.logger = logger
 	}
 }
+
+// WithTimeCallback uses the provided time function callback for getting the current time.
+func WithTimeCallback(timeCallback func() time.Time) Option {
+	return func(c *Cron) {
+		c.timeCallback = timeCallback
+	}
+}


### PR DESCRIPTION
Add some `Jitter` to the Entry's scheduled time. The actual jitter used will be randomly chosen within the range [0, Jitter]. The jitter will always be converted to a positive duration. Plus:

* `AddFuncWithJitter` adds a func to the Cron to be run on the given schedule. The spec is parsed using the time zone of this Cron instance as the default. An opaque ID is returned that can be used to later remove it.

* `AddJobWithJitter` adds a Job to the Cron to be run on the given schedule with a specified amount of jitter for each invocation. The spec is parsed using the time zone of this Cron instance as the default. An opaque ID is returned that can be used to later remove it.

* `ScheduleWithJitter` adds a Job to the Cron to be run on the given schedule with a specified amount of jitter for each invocation. The job is wrapped with the configured Chain.

* `WithTimeCallback` uses the provided time function callback for getting the current time.

