### PR TITLE
feat: add AddFuncWithID and AddJobWithID to schedule jobs with predef…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+/main

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/robfig/cron/v3
+module github.com/Yunnie-pin/cron/v3
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Yunnie-pin/cron/v3
+module github.com/Yunnie-pin/cron
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/robfig/cron/v3
+module github.com/Yunnie-pin/cron
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Yunnie-pin/cron
+module github.com/robfig/cron/v3
 
 go 1.12


### PR DESCRIPTION
- Implement AddFuncWithID to schedule func() jobs with a specified ID
- Implement AddJobWithID to schedule Job interface jobs with a specified ID
- Add error handling for duplicate job IDs

These new methods allow users to assign predefined IDs to cron jobs, 
giving more control and flexibility over job management.