### PR TITLE
Don't skip crons when time jumps forward due to DST

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -140,8 +140,16 @@ WRAP:
 			added = true
 			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, loc)
 		}
+		prev := t
 		t = t.Add(1 * time.Hour)
-
+		// ISC cron behavior: If time was adjusted one hour forward, those jobs
+		// that would have run in the interval that has been skipped will be run
+		// immediately.
+		if t.Hour()-prev.Hour() == 2 {
+			if 1<<uint(t.Hour()-1)&s.Hour > 0 {
+				break
+			}
+		}
 		if t.Hour() == 0 {
 			goto WRAP
 		}

--- a/spec_test.go
+++ b/spec_test.go
@@ -111,7 +111,7 @@ func TestNext(t *testing.T) {
 		{"Mon Jul 9 23:35 2012", "0 0 0 29 Feb ?", "Mon Feb 29 00:00 2016"},
 
 		// Daylight savings time 2am EST (-5) -> 3am EDT (-4)
-		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 30 2 11 Mar ?", "2013-03-11T02:30:00-0400"},
+		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 30 2 11 Mar ?", "2012-03-11T03:30:00-0400"},
 
 		// hourly job
 		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 0 * * * ?", "2012-03-11T01:00:00-0500"},
@@ -129,8 +129,8 @@ func TestNext(t *testing.T) {
 		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 0 1 * * ?", "2012-03-11T01:00:00-0500"},
 		{"2012-03-11T01:00:00-0500", "TZ=America/New_York 0 0 1 * * ?", "2012-03-12T01:00:00-0400"},
 
-		// 2am nightly job (skipped)
-		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 0 2 * * ?", "2012-03-12T02:00:00-0400"},
+		// Daylight savings time 2am EST (-5) -> 3am EDT (-4)
+		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 0 2 * * ?", "2012-03-11T03:00:00-0400"},
 
 		// Daylight savings time 2am EDT (-4) => 1am EST (-5)
 		{"2012-11-04T00:00:00-0400", "TZ=America/New_York 0 30 2 04 Nov ?", "2012-11-04T02:30:00-0500"},


### PR DESCRIPTION
We're investigating a production bug at Monzo where a 2:00 AM US/Pacific cron was skipped on 2025-03-09. We discovered the root cause is the https://github.com/robfig/cron library skips jobs that are scheduled during the interval when time jumps forward due to DST changes.

It seems the library's behavior is a bit non-standard in this regard, and differs from ISC cron which is used in most distributions of Linux and BSDs: 

> https://man7.org/linux/man-pages/man8/cron.8.html
>
> If time was adjusted one hour forward, those jobs that would have run in the interval that has  been  skipped  will  be  run immediately.

This PR aligns the behavior of the library with ISC cron.